### PR TITLE
Feat/#10/assignment 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/dataSources.xml
+.idea/dataSources.local.xml
 *.iws
 *.iml
 *.ipr

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,17 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="assignment@localhost [2]" uuid="dbe39d0a-21ba-4bff-bb88-ca8313f8823a">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/assignment</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,19 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    // retry
+    implementation 'org.springframework.retry:spring-retry'
+    // querydsl — Spring Boot 3.x는 Jakarta EE이므로 반드시 ':jakarta' classifier 사용
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+// QueryDSL이 생성하는 Q 클래스의 출력 경로를 IDE와 컴파일러가 소스로 인식하도록 등록
+def querydslDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main")
+sourceSets {
+    main.java.srcDirs += [querydslDir]
 }

--- a/src/main/java/org/sopt/domain/like/controller/LikeController.java
+++ b/src/main/java/org/sopt/domain/like/controller/LikeController.java
@@ -1,0 +1,54 @@
+package org.sopt.domain.like.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.sopt.domain.like.dto.request.LikeRequest;
+import org.sopt.domain.like.exception.code.LikeSuccessCode;
+import org.sopt.domain.like.service.LikeService;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Like", description = "좋아요 관련 API")
+@RestController
+@RequestMapping("/api/v1/posts/{postId}/likes")
+public class LikeController {
+
+  private final LikeService likeService;
+
+  public LikeController(LikeService likeService) {
+    this.likeService = likeService;
+  }
+
+  @Operation(summary = "좋아요 추가", description = "특정 게시글에 좋아요를 누릅니다. 같은 게시글에 중복 좋아요는 불가합니다.")
+  @PostMapping
+  public ResponseEntity<BaseResponse<Void>> addLike(
+      @PathVariable Long postId,
+      @Valid @RequestBody LikeRequest request
+  ) {
+    likeService.addLike(postId, request.userId());
+    return ResponseEntity
+        .status(LikeSuccessCode.LIKE_SUCCESS.getHttpStatus())
+        .body(BaseResponse.onSuccess(LikeSuccessCode.LIKE_SUCCESS, null));
+  }
+
+  @Operation(summary = "좋아요 취소", description = "특정 게시글에 누른 좋아요를 취소합니다.")
+  @DeleteMapping
+  public ResponseEntity<BaseResponse<Void>> cancelLike(
+      @PathVariable Long postId,
+      @NotNull @RequestParam Long userId
+  ) {
+    likeService.cancelLike(postId, userId);
+    return ResponseEntity
+        .status(LikeSuccessCode.LIKE_CANCEL_SUCCESS.getHttpStatus())
+        .body(BaseResponse.onSuccess(LikeSuccessCode.LIKE_CANCEL_SUCCESS, null));
+  }
+}

--- a/src/main/java/org/sopt/domain/like/dto/request/LikeRequest.java
+++ b/src/main/java/org/sopt/domain/like/dto/request/LikeRequest.java
@@ -1,0 +1,11 @@
+package org.sopt.domain.like.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "좋아요 요청")
+public record LikeRequest(
+    @Schema(description = "사용자 ID", example = "1")
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    Long userId
+) {}

--- a/src/main/java/org/sopt/domain/like/entity/Like.java
+++ b/src/main/java/org/sopt/domain/like/entity/Like.java
@@ -1,0 +1,51 @@
+package org.sopt.domain.like.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.sopt.domain.post.entity.Post;
+import org.sopt.domain.user.entity.User;
+import org.sopt.global.entity.BaseTimeEntity;
+
+@Entity
+@Table(
+    name = "likes",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_likes_user_post",
+        columnNames = {"user_id", "post_id"}
+    )
+)
+public class Like extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)  // Post 삭제 시 DB 레벨에서 연관 Like 자동 삭제
+  private Post post;
+
+  protected Like() {}
+
+  public Like(User user, Post post) {
+    this.user = user;
+    this.post = post;
+  }
+
+  public Long getId() { return id; }
+  public User getUser() { return user; }
+  public Post getPost() { return post; }
+}

--- a/src/main/java/org/sopt/domain/like/exception/LikeException.java
+++ b/src/main/java/org/sopt/domain/like/exception/LikeException.java
@@ -1,0 +1,11 @@
+package org.sopt.domain.like.exception;
+
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.code.BaseErrorCode;
+
+public class LikeException extends CustomException {
+
+  public LikeException(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/org/sopt/domain/like/exception/code/LikeErrorCode.java
+++ b/src/main/java/org/sopt/domain/like/exception/code/LikeErrorCode.java
@@ -1,0 +1,32 @@
+package org.sopt.domain.like.exception.code;
+
+import org.sopt.global.exception.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum LikeErrorCode implements BaseErrorCode {
+
+  LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "LIKE4091", "이미 좋아요를 누른 게시글입니다."),
+  LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "LIKE4041", "좋아요를 누르지 않은 게시글입니다."),
+  LIKE_USER_REQUIRED(HttpStatus.BAD_REQUEST, "LIKE4001", "사용자 ID는 필수입니다."),
+  // 재시도 횟수를 모두 소진했을 때 최종 응답 — 클라이언트에게 재시도 안내
+  LIKE_CONCURRENT_CONFLICT(HttpStatus.CONFLICT, "LIKE4092", "요청이 집중되고 있습니다. 잠시 후 다시 시도해주세요.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  LikeErrorCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() { return httpStatus; }
+
+  @Override
+  public String getCode() { return code; }
+
+  @Override
+  public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/domain/like/exception/code/LikeSuccessCode.java
+++ b/src/main/java/org/sopt/domain/like/exception/code/LikeSuccessCode.java
@@ -1,0 +1,29 @@
+package org.sopt.domain.like.exception.code;
+
+import org.sopt.global.exception.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum LikeSuccessCode implements BaseSuccessCode {
+
+  LIKE_SUCCESS(HttpStatus.CREATED, "LIKE2011", "좋아요를 눌렀습니다."),
+  LIKE_CANCEL_SUCCESS(HttpStatus.OK, "LIKE2001", "좋아요를 취소했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  LikeSuccessCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() { return httpStatus; }
+
+  @Override
+  public String getCode() { return code; }
+
+  @Override
+  public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/domain/like/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/domain/like/repository/LikeRepository.java
@@ -1,0 +1,20 @@
+package org.sopt.domain.like.repository;
+
+import org.sopt.domain.like.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+
+  boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+  // void deleteByUserIdAndPostId(Long userId, Long postId);
+  // 개선: 단일 벌크 DELETE (1 query)
+  @Modifying
+  @Query("DELETE FROM Like l WHERE l.user.id = :userId AND l.post.id = :postId")
+  void deleteByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
+}

--- a/src/main/java/org/sopt/domain/like/service/LikeService.java
+++ b/src/main/java/org/sopt/domain/like/service/LikeService.java
@@ -1,0 +1,102 @@
+package org.sopt.domain.like.service;
+
+import org.sopt.domain.like.entity.Like;
+import org.sopt.domain.like.exception.LikeException;
+import org.sopt.domain.like.exception.code.LikeErrorCode;
+import org.sopt.domain.like.repository.LikeRepository;
+import org.sopt.domain.post.entity.Post;
+import org.sopt.domain.post.exception.PostException;
+import org.sopt.domain.post.exception.code.PostErrorCode;
+import org.sopt.domain.post.repository.PostRepository;
+import org.sopt.domain.user.entity.User;
+import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.code.GlobalErrorCode;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LikeService {
+
+  private final LikeRepository likeRepository;
+  private final PostRepository postRepository;
+  private final UserRepository userRepository;
+
+  public LikeService(
+      LikeRepository likeRepository,
+      PostRepository postRepository,
+      UserRepository userRepository
+  ) {
+    this.likeRepository = likeRepository;
+    this.postRepository = postRepository;
+    this.userRepository = userRepository;
+  }
+
+  // @Retryable이 @Transactional 바깥을 감싸는 프록시로 동작한다.
+  // 실행 순서: Retry 인터셉터 → 트랜잭션 시작 → 비즈니스 로직 → 트랜잭션 커밋(version 체크)
+  // 커밋 시 version 불일치 → OptimisticLockingFailureException → 트랜잭션 롤백 후 Retry 인터셉터가 포착 → 새 트랜잭션으로 재시도
+  // noRetryFor = CustomException: PostException 등 비즈니스 예외는 재시도·복구 과정을 건너뛰고 즉시 전파
+  // 없으면 @Recover 타입 불일치로 ClassCastException → 500 응답
+  @Retryable(
+      retryFor = OptimisticLockingFailureException.class,
+      noRetryFor = CustomException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100, multiplier = 2)
+  )
+  @Transactional
+  public void addLike(Long postId, Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(GlobalErrorCode.COMMON_BAD_REQUEST));
+
+    // version 필드가 있는 Post를 로딩 — 이 시점의 version이 커밋 시 기준값이 된다
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+    if (likeRepository.existsByUserIdAndPostId(userId, postId)) {
+      throw new LikeException(LikeErrorCode.LIKE_ALREADY_EXISTS);
+    }
+
+    likeRepository.save(new Like(user, post));
+    // likeCount 변경 → JPA가 Post를 dirty 감지 → UPDATE post SET like_count=?, version=? WHERE id=? AND version=?
+    // 다른 트랜잭션이 먼저 커밋했다면 WHERE version=? 조건 불일치 → OptimisticLockingFailureException
+    post.incrementLikeCount();
+  }
+
+  @Retryable(
+      retryFor = OptimisticLockingFailureException.class,
+      noRetryFor = CustomException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100, multiplier = 2)
+  )
+  @Transactional
+  public void cancelLike(Long postId, Long userId) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+    if (!likeRepository.existsByUserIdAndPostId(userId, postId)) {
+      throw new LikeException(LikeErrorCode.LIKE_NOT_FOUND);
+    }
+
+    likeRepository.deleteByUserIdAndPostId(userId, postId);
+    post.decrementLikeCount();
+  }
+
+  // 재시도를 maxAttempts 횟수만큼 소진한 후 최종 호출되는 복구 메서드
+  // 반환 타입과 파라미터 타입이 @Retryable 메서드와 일치해야 Spring Retry가 연결한다
+  @Recover
+  public void recover(OptimisticLockingFailureException e, Long postId, Long userId) {
+    throw new LikeException(LikeErrorCode.LIKE_CONCURRENT_CONFLICT);
+  }
+
+  // @Recover 매칭 실패 시 500으로 새어나오는 것을 막는 catch-all
+  // Spring Retry는 예외 계층상 가장 가까운 @Recover를 선택하므로 위 메서드와 충돌하지 않는다
+  @Recover
+  public void recover(Exception e, Long postId, Long userId) {
+    if (e instanceof RuntimeException re) throw re;
+    throw new RuntimeException(e);
+  }
+}

--- a/src/main/java/org/sopt/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/domain/post/controller/PostController.java
@@ -11,10 +11,12 @@ import org.sopt.domain.post.entity.BoardType;
 import org.sopt.domain.post.exception.code.PostSuccessCode;
 import org.sopt.domain.post.service.PostService;
 import org.sopt.global.response.BaseResponse;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post", description = "게시글 관련 API")
+@Validated  // @RequestParam의 @NotBlank 등 제약 어노테이션을 활성화 (@Valid는 @RequestBody에만 동작)
 @RestController
 @RequestMapping("/api/v1/posts")
 public class PostController {
@@ -52,7 +55,7 @@ public class PostController {
   @GetMapping
   public ResponseEntity<BaseResponse<PostPageResponse>> getAllPosts(
       @RequestParam(required = false) BoardType boardType,
-      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+      @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
   ) {
     PostPageResponse response = postService.getPosts(boardType, pageable);
     return ResponseEntity
@@ -81,6 +84,23 @@ public class PostController {
     return ResponseEntity
         .status(PostSuccessCode.POST_UPDATE_SUCCESS.getHttpStatus())
         .body(BaseResponse.onSuccess(PostSuccessCode.POST_UPDATE_SUCCESS, response));
+  }
+
+  // /search가 /{id}보다 먼저 선언되어야 "search"가 PathVariable id로 잘못 매핑되지 않는다
+  @Operation(
+      summary = "게시글 동적 검색",
+      description = "제목 키워드와 작성자 닉네임을 선택적으로 조합해 검색합니다. 둘 다 생략하면 전체 조회와 동일합니다."
+  )
+  @GetMapping("/search")
+  public ResponseEntity<BaseResponse<PostPageResponse>> searchPosts(
+      @RequestParam(required = false) String titleKeyword,
+      @RequestParam(required = false) String authorNickname,
+      @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+  ) {
+    PostPageResponse response = postService.searchPosts(titleKeyword, authorNickname, pageable);
+    return ResponseEntity
+        .status(PostSuccessCode.POST_SEARCH_SUCCESS.getHttpStatus())
+        .body(BaseResponse.onSuccess(PostSuccessCode.POST_SEARCH_SUCCESS, response));
   }
 
   @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")

--- a/src/main/java/org/sopt/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/domain/post/dto/response/PostResponse.java
@@ -16,6 +16,8 @@ public record PostResponse(
     String content,
     @Schema(description = "작성자 닉네임", example = "솝트햄")
     String author,
+    @Schema(description = "좋아요 수", example = "42")
+    long likeCount,
     @Schema(description = "생성일시", example = "2024-04-26 11:00:00")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     LocalDateTime createdAt,
@@ -31,6 +33,7 @@ public record PostResponse(
         post.getTitle(),
         post.getContent(),
         post.getUser().getNickname(),
+        post.getLikeCount(),
         post.getCreatedAt(),
         post.getUpdatedAt(),
         post.getBoardType()

--- a/src/main/java/org/sopt/domain/post/entity/Post.java
+++ b/src/main/java/org/sopt/domain/post/entity/Post.java
@@ -10,31 +10,43 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import org.sopt.domain.user.entity.User;
 import org.sopt.global.entity.BaseTimeEntity;
 
 @Entity
 public class Post extends BaseTimeEntity {
 
-  @Id // 앞에서 배운 PK
+  @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Column(nullable = false, length = 100)
-  private String title;     // 목록, 상세, 글쓰기 화면 — 제목
+  private String title;
 
   @Column(nullable = false, columnDefinition = "TEXT")
-  private String content;   // 목록(미리보기), 상세(전체) 화면 — 내용
+  private String content;
 
-  @ManyToOne(fetch = FetchType.LAZY)  // User : Post = 1 : N
-  @JoinColumn(name = "user_id")       // post 테이블에 user_id FK 컬럼 추가
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
   private User user;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 20)
-  private BoardType boardType; // 필드 추가
+  private BoardType boardType;
 
-  protected Post() {}  // JPA 기본 생성자
+  // 낙관적 락의 핵심: 커밋 시 UPDATE post SET version = ? WHERE id = ? AND version = ?
+  // 기댓값과 실제값이 다르면 OptimisticLockingFailureException 발생
+  @Version
+  @Column(columnDefinition = "BIGINT DEFAULT 0")
+  private Long version;
+
+  // 좋아요 수 비정규화 — 별도 COUNT 쿼리 없이 Post 조회만으로 응답 가능
+  // likeCount를 변경함으로써 version 체크가 트리거되어 동시성을 제어한다
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private long likeCount = 0;
+
+  protected Post() {}
 
   public Post(Long id, String title, String content, User user, BoardType boardType) {
     this.id = id;
@@ -49,9 +61,19 @@ public class Post extends BaseTimeEntity {
   public String getContent() { return content; }
   public BoardType getBoardType() { return boardType; }
   public User getUser() { return user; }
+  public long getLikeCount() { return likeCount; }
 
   public void update(String title, String content) {
     this.title = title;
     this.content = content;
+  }
+
+  public void incrementLikeCount() {
+    this.likeCount++;
+  }
+
+  public void decrementLikeCount() {
+    // 좋아요 존재 여부를 먼저 검증한 후 호출하지만, 방어적으로 음수 방지
+    if (this.likeCount > 0) this.likeCount--;
   }
 }

--- a/src/main/java/org/sopt/domain/post/exception/code/PostErrorCode.java
+++ b/src/main/java/org/sopt/domain/post/exception/code/PostErrorCode.java
@@ -11,7 +11,8 @@ public enum PostErrorCode implements BaseErrorCode {
   POST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4001", "제목은 필수 입력 항목입니다."),
   POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST4002", "내용을 입력해주세요."),
   POST_AUTHOR_REQUIRED(HttpStatus.BAD_REQUEST, "POST4003", "작성자 ID는 필수입니다."),
-  POST_BOARD_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4004", "게시판 종류는 필수입니다.");
+  POST_BOARD_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4004", "게시판 종류는 필수입니다."),
+  POST_SEARCH_KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "POST4005", "검색어를 입력해주세요.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/org/sopt/domain/post/exception/code/PostSuccessCode.java
+++ b/src/main/java/org/sopt/domain/post/exception/code/PostSuccessCode.java
@@ -9,7 +9,8 @@ public enum PostSuccessCode implements BaseSuccessCode {
   POST_GET_ALL_SUCCESS(HttpStatus.OK, "POST2001", "게시글 전체 조회에 성공했습니다."),
   POST_GET_SUCCESS(HttpStatus.OK, "POST2002", "게시글 단건 조회에 성공했습니다."),
   POST_UPDATE_SUCCESS(HttpStatus.OK, "POST2003", "게시글 수정에 성공했습니다."),
-  POST_DELETE_SUCCESS(HttpStatus.OK, "POST2004", "게시글 삭제에 성공했습니다.");
+  POST_DELETE_SUCCESS(HttpStatus.OK, "POST2004", "게시글 삭제에 성공했습니다."),
+  POST_SEARCH_SUCCESS(HttpStatus.OK, "POST2005", "게시글 검색에 성공했습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/org/sopt/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/sopt/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.domain.post.repository;
 
+import java.util.Optional;
 import org.sopt.domain.post.entity.BoardType;
 import org.sopt.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
@@ -9,10 +10,32 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+// JpaRepository: 기본 CRUD + 페이징
+// PostRepositoryCustom: QueryDSL 기반 동적 검색
+// Spring Data가 두 인터페이스의 구현을 하나의 프록시로 합성해준다
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
-  // 특정 게시판 타입의 글들을 조회하는 메서드
-  @Query("select p from Post p join fetch p.user where p.boardType = :boardType")
+  // ManyToOne fetch join은 페이징과 함께 사용해도 안전 (OneToMany와 달리 Cartesian product 없음)
+  @Query("SELECT p FROM Post p JOIN FETCH p.user")
+  Page<Post> findAllWithUser(Pageable pageable);
+
+  @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.boardType = :boardType")
   Page<Post> findAllByBoardTypeWithUser(@Param("boardType") BoardType boardType, Pageable pageable);
+
+  // 단건 조회 시 user 지연 로딩 방지
+  @Query("SELECT p FROM Post p JOIN FETCH p.user WHERE p.id = :id")
+  Optional<Post> findByIdWithUser(@Param("id") Long id);
+
+  // countQuery를 별도로 분리하는 이유:
+  // Page<T> 반환 시 Spring Data는 totalElements를 위한 COUNT 쿼리를 자동 생성하는데,
+  // JOIN FETCH를 COUNT에 그대로 적용하면 "query specified join fetching, but the owner of the fetched association was not present" 오류 발생.
+  // COUNT 쿼리에서는 JOIN FETCH 불필요 — 단순 JOIN으로 충분하고 실제로는 조인도 필요 없어 p만으로 카운팅.
+  @Query(
+      value = "SELECT p FROM Post p JOIN FETCH p.user " +
+              "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))",
+      countQuery = "SELECT COUNT(p) FROM Post p " +
+                   "WHERE LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))"
+  )
+  Page<Post> searchByTitleContainingIgnoreCase(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/org/sopt/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/org/sopt/domain/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.sopt.domain.post.repository;
+
+import org.sopt.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+
+  // 제목/작성자 닉네임을 선택적으로 조합한 동적 검색 — null/빈 문자열 조건은 쿼리에서 제외된다
+  Page<Post> searchDynamically(String titleKeyword, String authorNickname, Pageable pageable);
+}

--- a/src/main/java/org/sopt/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/org/sopt/domain/post/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,97 @@
+package org.sopt.domain.post.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparablePath;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import org.sopt.domain.post.entity.Post;
+import org.sopt.domain.post.entity.QPost;
+import org.sopt.domain.user.entity.QUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+// @Repository 없음 — Spring Data가 '{프래그먼트명}Impl' 규칙으로 자동 탐지하고 DI를 처리한다.
+// @Repository를 붙이면 별도 Bean으로 이중 등록되어 문제가 생길 수 있다.
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+  private static final QPost post = QPost.post;
+  private static final QUser user = QUser.user;
+
+  private final JPAQueryFactory queryFactory;
+
+  public PostRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+    this.queryFactory = queryFactory;
+  }
+
+  @Override
+  public Page<Post> searchDynamically(String titleKeyword, String authorNickname, Pageable pageable) {
+    // Content 쿼리: fetchJoin으로 user를 함께 로딩 (N+1 방지, PostResponse.author 필드용)
+    List<Post> content = queryFactory
+        .selectFrom(post)
+        .join(post.user, user).fetchJoin()
+        .where(
+            titleContains(titleKeyword),      // null이면 QueryDSL이 조건에서 자동 제외
+            authorNicknameContains(authorNickname)
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(toOrderSpecifiers(pageable.getSort()))
+        .fetch();
+
+    // Count 쿼리: fetchJoin 없이 순수 카운팅
+    // authorNickname 조건이 있을 때만 user JOIN — 없으면 불필요한 JOIN 생략
+    JPAQuery<Long> countQuery = queryFactory
+        .select(post.count())
+        .from(post);
+
+    if (StringUtils.hasText(authorNickname)) {
+      countQuery.join(post.user, user);
+    }
+
+    long total = countQuery
+        .where(
+            titleContains(titleKeyword),
+            authorNicknameContains(authorNickname)
+        )
+        .fetchOne();
+
+    return new PageImpl<>(content, pageable, total);
+  }
+
+  // BooleanExpression을 반환하고 null을 허용하는 이유:
+  // QueryDSL의 where(expr...)는 null인 인자를 AND에서 조용히 제외한다.
+  // BooleanBuilder 대비 각 조건이 독립적이어서 테스트와 조합이 쉽다.
+  private BooleanExpression titleContains(String keyword) {
+    return StringUtils.hasText(keyword) ? post.title.containsIgnoreCase(keyword) : null;
+  }
+
+  private BooleanExpression authorNicknameContains(String nickname) {
+    return StringUtils.hasText(nickname) ? post.user.nickname.containsIgnoreCase(nickname) : null;
+  }
+
+  // Pageable의 Sort를 QueryDSL OrderSpecifier 배열로 변환
+  // PathBuilder를 쓰는 이유: 필드명을 런타임 문자열로 받아 동적으로 경로를 구성해야 하기 때문.
+  // QPost.post.createdAt처럼 정적으로 쓰면 새 정렬 조건이 생길 때마다 코드 수정이 필요하다.
+  @SuppressWarnings("unchecked")
+  private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+    if (sort.isUnsorted()) {
+      return new OrderSpecifier<?>[]{ post.createdAt.desc() };
+    }
+
+    PathBuilder<Post> postPath = new PathBuilder<>(Post.class, "post");
+
+    return sort.stream()
+        .map(order -> {
+          ComparablePath<Comparable> path =
+              postPath.getComparable(order.getProperty(), Comparable.class);
+          return order.isAscending() ? path.asc() : path.desc();
+        })
+        .toArray(OrderSpecifier[]::new);
+  }
+}

--- a/src/main/java/org/sopt/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PostService {
+
   private final PostRepository postRepository;
   private final UserRepository userRepository;
 
@@ -29,32 +30,28 @@ public class PostService {
     this.userRepository = userRepository;
   }
 
-  // CREATE - 게시글 생성
-  @Transactional  // 저장 → DB 변경 발생 → 트랜잭션 커밋 시 반영
+  @Transactional
   public PostResponse createPost(CreatePostRequest request) {
-    // 1. 작성자 존재 여부 확인
     User user = userRepository.findById(request.userId())
         .orElseThrow(() -> new CustomException(GlobalErrorCode.COMMON_BAD_REQUEST));
 
-    Post post = new Post(
-        null, // ID는 DB에서 자동 생성(IDENTITY)
+    Post savedPost = postRepository.save(new Post(
+        null,
         request.title(),
         request.content(),
         user,
         request.boardType()
-    );
-
-    Post savedPost = postRepository.save(post);
+    ));
     return PostResponse.from(savedPost);
   }
 
-  // READ - 전체 조회 (boardtype 없으면 전체 조회, 있으면 해당 타입의 게시글 전체조회)
   // Pageable은 컨트롤러에서 Spring이 만들어주고, Repository에 그대로 넘겨 DB 레벨에서 정렬/페이징 처리
+  // likeCount는 Post 엔티티에 비정규화되어 있으므로 별도 COUNT 쿼리 없이 JOIN FETCH 1번으로 해결
   @Transactional(readOnly = true)
   public PostPageResponse getPosts(BoardType boardType, Pageable pageable) {
     Page<Post> postPage = (boardType != null)
         ? postRepository.findAllByBoardTypeWithUser(boardType, pageable)
-        : postRepository.findAll(pageable);
+        : postRepository.findAllWithUser(pageable);
 
     List<PostResponse> content = postPage.getContent().stream()
         .map(PostResponse::from)
@@ -71,31 +68,48 @@ public class PostService {
     );
   }
 
-  // READ - 단건 조회
-  @Transactional(readOnly = true)  // 조회 전용 → 더티 체킹 안 함
+  @Transactional(readOnly = true)
   public PostResponse getPost(Long id) {
-    Post post = postRepository.findById(id)
+    Post post = postRepository.findByIdWithUser(id)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
     return PostResponse.from(post);
   }
 
-  // UPDATE - 수정
   @Transactional
   public PostResponse updatePost(Long id, UpdatePostRequest request) {
-    Post post = postRepository.findById(id)
+    Post post = postRepository.findByIdWithUser(id)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
     post.update(request.title(), request.content());
     return PostResponse.from(post);
   }
 
-  // DELETE - 삭제
   @Transactional
   public void deletePost(Long id) {
     Post post = postRepository.findById(id)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
-    postRepository.deleteById(post.getId());
+    postRepository.delete(post);
+  }
+
+  // titleKeyword, authorNickname 모두 null/빈 문자열 허용 — QueryDSL이 동적으로 조건을 조합
+  @Transactional(readOnly = true)
+  public PostPageResponse searchPosts(String titleKeyword, String authorNickname, Pageable pageable) {
+    Page<Post> postPage = postRepository.searchDynamically(titleKeyword, authorNickname, pageable);
+
+    List<PostResponse> content = postPage.getContent().stream()
+        .map(PostResponse::from)
+        .toList();
+
+    return new PostPageResponse(
+        content,
+        postPage.getNumber(),
+        postPage.getSize(),
+        (int) postPage.getTotalElements(),
+        postPage.getTotalPages(),
+        postPage.isFirst(),
+        postPage.isLast()
+    );
   }
 }

--- a/src/main/java/org/sopt/global/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/org/sopt/global/config/RetryConfig.java
+++ b/src/main/java/org/sopt/global/config/RetryConfig.java
@@ -1,0 +1,8 @@
+package org.sopt.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry  // @Retryable, @Recover 어노테이션 활성화
+public class RetryConfig {}

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package org.sopt.global.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.sopt.domain.like.exception.code.LikeErrorCode;
 import org.sopt.domain.post.exception.code.PostErrorCode;
 import org.sopt.global.exception.code.BaseErrorCode;
 import org.sopt.global.exception.code.GlobalErrorCode;
@@ -33,6 +35,23 @@ public class GlobalExceptionHandler {
         .body(BaseResponse.onFailure("COMMON5001", "서버 에러가 발생했습니다."));
   }
 
+  // @RequestParam, @PathVariable 등에 붙은 제약 어노테이션 위반 시 발생
+  // @RequestBody의 @Valid → MethodArgumentNotValidException과 다른 예외임에 주의
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<BaseResponse<Void>> handleConstraintViolationException(ConstraintViolationException e) {
+    String message = e.getConstraintViolations().iterator().next().getMessage();
+    BaseErrorCode errorCode = findErrorCodeByMessage(message);
+
+    if (errorCode != null) {
+      return ResponseEntity
+          .status(errorCode.getHttpStatus())
+          .body(BaseResponse.onFailure(errorCode.getCode(), errorCode.getMessage()));
+    }
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(BaseResponse.onFailure("COMMON4001", message));
+  }
+
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<BaseResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
     // 1. DTO에서 터진 에러 메시지 추출
@@ -58,7 +77,7 @@ public class GlobalExceptionHandler {
 
   static {
     // 애플리케이션 실행 시 딱 한 번만 모든 메시지를 맵에 담아둠
-    List<Class<? extends BaseErrorCode>> enums = List.of(PostErrorCode.class, GlobalErrorCode.class);
+    List<Class<? extends BaseErrorCode>> enums = List.of(PostErrorCode.class, LikeErrorCode.class, GlobalErrorCode.class);
     for (Class<? extends BaseErrorCode> enumClass : enums) {
       for (BaseErrorCode code : enumClass.getEnumConstants()) {
         errorCodeMap.put(code.getMessage(), code);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
+        use_sql_comments: true  # JPQL → SQL 변환 추적용 (PR 쿼리 비교 시 유용)
     show-sql: true
 
   springdoc:


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] User 엔티티를 만들고, Post에 작성자 연관관계를 추가해주세요. 게시글 작성 시 userId를 받아서 연결해주세요
- [x] 전체 API에 Swagger 어노테이션을 적용하고, Swagger UI에서 API를 직접 테스트해보세요. 테스트 화면을 PR에 첨부해주세요
- [x] BaseTimeEntity를 게시글에 적용해주세요  
필수 과제는 https://github.com/38-lets-sopt-server/haemin.yoon/pull/11 에서 정리했습니다.

<br>

### 선택과제
- [x] Like 엔티티를 만들고, 좋아요 추가/취소 API를 구현해주세요. 같은 유저가 같은 게시글에 중복 좋아요를 누를 수 없게 예외처리해주세요
- [x] 게시글 목록 조회 시 좋아요 수도 함께 반환해주세요. N+1 문제가 발생하지 않도록 fetch join을 적용하고, 적용 전후 실행되는 쿼리를 show-sql: true로 확인해서 PR에 비교해서 첨부해주세요
- [x] 좋아요 동시성 문제를 @Version으로 해결하고, 낙관적 락 충돌 시 재시도 로직을 구현해주세요
- [x] 게시글을 제목으로 검색하는 API를 JPQL @Query를 사용해서 구현해주세요. 검색 결과에 작성자 닉네임도 함께 반환하고, fetch join으로 N+1이 발생하지 않도록 해주세요
- [x] PostRepositoryCustom 인터페이스와 PostRepositoryCustomImpl 구현체를 만들고, 위의 검색 기능을 QueryDSL로 재구현해주세요. 제목 키워드와 작성자 닉네임을 동시에 받아 동적으로 조건을 조합해주세요. PostRepository가 JpaRepository와 PostRepositoryCustom을 함께 상속하도록 구성해주세요

<br>

### **구현한 내용에 대해서 설명해주세요**

1. 필수 요구사항

  - Like 엔티티 및 좋아요 추가/취소 API
    - Like 엔티티를 별도 surrogate PK + user_id + post_id unique constraint로 설계했습니다.
    - POST /api/v1/posts/{postId}/likes, DELETE /api/v1/posts/{postId}/likes 두 엔드포인트를 구현했습니다.
    - 중복 좋아요는 DB 제약조건과 서비스 레이어 이중으로 방어합니다.
  - 게시글 목록 응답에 좋아요 수 포함
    - likeCount를 Post 엔티티에 비정규화했습니다.
    - 별도 COUNT 쿼리 없이 기존 JOIN FETCH 한 번으로 모든 데이터를 가져오므로 추가 쿼리가 발생하지 않습니다.
  - 낙관적 락(@Version) + 재시도 로직
    - Post에 @Version을 적용하고, likeCount 변경으로 version 체크가 트리거되도록 했습니다.
    - 충돌 시 @Retryable로 최대 3회, 지수 백오프(100ms → 200ms)로 재시도합니다.
    - 재시도 소진 시 @Recover에서 LIKE_CONCURRENT_CONFLICT로 응답합니다.
  - JPQL 제목 검색
    - JPQL 제목 검색: JOIN FETCH와 Page<T>를 함께 쓸 때 COUNT 쿼리에서 발생하는 오류를 막기 위해 countQuery를 명시적으로 분리해 구현했습니다. 이후 5번 과제에서 QueryDSL 동적 검색을 도입하면서 실제 검색 엔드포인트는 QueryDSL로 대체했습니다.
  - QueryDSL 동적 검색
    - PostRepositoryCustom / PostRepositoryCustomImpl 프래그먼트 패턴으로 구현했습니다.
    - 각 조건을 BooleanExpression으로 분리해 null이면 QueryDSL이 자동 제외합니다.
    - count 쿼리는 authorNickname 조건이 있을 때만 user JOIN을 수행합니다.

  2. 추가로 진행한 개선

  - deleteByUserIdAndPostId N+1 제거: 파생 delete 메서드는 내부적으로 SELECT 후 건별 DELETE라 N+1이 발생합니다. @Modifying @Query로 벌크 DELETE 한 쿼리로 변경했습니다.
  - 불필요한 재조회 제거: deleteById(post.getId())는 내부에서 findById를 한 번 더 호출합니다. 이미 로딩된 엔티티를 그대로 사용하도록 delete(post)로 변경했습니다.
  - noRetryFor + catch-all @Recover 추가: 비즈니스 예외가 retry/recovery 경로를 통해 500으로 새어나오는 문제를 방지했습니다.
  - count 쿼리 조건부 JOIN 구현: 닉네임 조건이 없을 때 불필요한 user JOIN을 제거했습니다.

  ---

<br>

### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

1. Like PK 설계 — surrogate PK vs @EmbeddedId

  처음에는 user_id + post_id 복합키(@EmbeddedId)로 설계했습니다. 하지만 복합키는 연관관계를 맺을 때 양쪽 PK를 모두 들고 다녀야 해서 확장이 불편하고, JPA에서도 다루기 까다롭습니다. 실무에서는 surrogate PK에 unique constraint로 중복만 방지하는 방식이 더 일반적이라 그 방향으로 변경했습니다.

  2. likeCount 비정규화와 @Version 트리거

  @Version은 해당 엔티티(Post)가 변경될 때만 version 체크가 트리거됩니다. Like를 저장하는 것만으로는 Post가 dirty 상태가 되지 않아 동시성 제어가 전혀 되지 않았습니다. Post에 likeCount를 비정규화하고 좋아요 시 이를 변경함으로써 Post를 dirty 상태로 만들어 version 체크를 유도했습니다. 결과적으로 N+1 방지와 동시성 제어를 동시에 해결하는 구조가 됐습니다.

  3. 낙관적 락을 선택한 이유

  좋아요는 충돌보다 성공이 압도적으로 많은 연산입니다. 비관적 락은 매 요청마다 DB 락을 잡아 성능 손실이  크고, 충돌이 드문 상황에서 과한 선택입니다. 낙관적 락은 충돌이 생겼을 때만 비용을 지불하므로 이 상황에 더 적합하다고 판단했습니다.

  4. @Retryable과 @Transactional 프록시 순서

  @Retryable이 @Transactional 바깥을 감싸야 재시도가 의미를 가집니다. 같은 트랜잭션 안에서 재시도하면 이미 충돌 난 version을 그대로 들고 재시도하게 되어 항상 실패합니다. Spring의 프록시 우선순위상 @Retryable이 바깥 프록시가 되므로 별도 설정 없이 올바른 순서가 보장된다는 걸 확인하고 넘어갔습니다.

  5. 예외 처리 문제에서 noRetryFor만으로는 부족했던 이유

  retryFor = OptimisticLockingFailureException.class만 설정하면 PostException 같은 비즈니스 예외가 재시도는 되지 않지만, Spring Retry는 여전히 recovery 경로(@Recover)를 거칩니다. 매칭되는 @Recover가 없으면 예외가 500으로 새어나오는 문제가 있었습니다. noRetryFor = CustomException.class로 재시도를 막고, catch-all @Recover(Exception e)로 recovery 경로에서도 올바르게 전파되도록 두 가지를 함께 적용해야 완전히 해결됐습니다.

<br>

---
### **키워드 과제 정리내용**


<br>

---

## 🚨 참고 사항
