### PR TITLE
Feat/#14/assignment 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Redis — 블랙리스트 토큰 관리 (TTL 자동 만료, 다중 인스턴스 공유)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 // QueryDSL이 생성하는 Q 클래스의 출력 경로를 IDE와 컴파일러가 소스로 인식하도록 등록

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // JWT
+    implementation 'com.auth0:java-jwt:4.4.0'
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 // QueryDSL이 생성하는 Q 클래스의 출력 경로를 IDE와 컴파일러가 소스로 인식하도록 등록

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: assignment-redis
+    ports:
+      - "6379:6379"
+    # 재시작 시 자동으로 컨테이너를 다시 시작 (개발 환경용)
+    restart: unless-stopped

--- a/src/main/java/org/sopt/domain/auth/client/GoogleOAuthClient.java
+++ b/src/main/java/org/sopt/domain/auth/client/GoogleOAuthClient.java
@@ -1,0 +1,133 @@
+package org.sopt.domain.auth.client;
+
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sopt.domain.auth.dto.response.GoogleTokenResponse;
+import org.sopt.domain.auth.dto.response.GoogleUserInfoResponse;
+import org.sopt.domain.auth.exception.AuthException;
+import org.sopt.domain.auth.exception.code.AuthErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Google OAuth 2.0 API 호출을 담당하는 클라이언트.
+ *
+ * ── Authorization Code Flow ─────────────────────────────────────────────
+ * 1. 클라이언트가 Google 인가 화면에서 authorization code를 받는다.
+ * 2. 클라이언트가 code를 우리 서버에 전달한다.
+ * 3. 서버(이 클래스)가 code로 Google token endpoint에서 access token을 교환한다.
+ * 4. 서버가 access token으로 Google userinfo endpoint에서 유저 정보를 조회한다.
+ *
+ * ── RestClient 사용 이유 ─────────────────────────────────────────────────
+ * Spring 6.1(Boot 3.2)에서 도입된 동기 HTTP 클라이언트.
+ * WebClient보다 간결하고 RestTemplate보다 현대적인 API를 제공함.
+ */
+@Component
+public class GoogleOAuthClient {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleOAuthClient.class);
+
+    private final RestClient restClient;
+    private final String clientId;
+    private final String clientSecret;
+    private final String authorizationUri;
+    private final String tokenUri;
+    private final String userInfoUri;
+    private final String callbackUri;
+
+    public GoogleOAuthClient(
+            @Value("${oauth.google.client-id}") String clientId,
+            @Value("${oauth.google.client-secret}") String clientSecret,
+            @Value("${oauth.google.authorization-uri}") String authorizationUri,
+            @Value("${oauth.google.token-uri}") String tokenUri,
+            @Value("${oauth.google.user-info-uri}") String userInfoUri,
+            @Value("${oauth.google.callback-uri}") String callbackUri
+    ) {
+        // RestClient.create()로 기본 설정의 RestClient 생성
+        // 빈으로 주입받지 않고 직접 생성하는 이유: GoogleOAuthClient 전용이라 공유할 필요 없음
+        this.restClient = RestClient.create();
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.authorizationUri = authorizationUri;
+        this.tokenUri = tokenUri;
+        this.userInfoUri = userInfoUri;
+        this.callbackUri = callbackUri;
+    }
+
+    /**
+     * Google 인가 화면 URL을 생성한다.
+     * client_id 등 민감한 값이 서버에서 조립되므로 프론트에 노출되지 않음.
+     */
+    public String buildAuthorizationUrl() {
+        return authorizationUri
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + callbackUri
+                + "&response_type=code"
+                + "&scope=email%20profile";
+    }
+
+    public String getCallbackUri() {
+        return callbackUri;
+    }
+
+    /**
+     * authorization code를 Google access token으로 교환한다.
+     *
+     * Google token endpoint는 application/x-www-form-urlencoded 형식을 요구함.
+     * redirect_uri는 code 발급 시 사용한 값과 정확히 일치해야 Google이 검증을 통과시킴.
+     */
+    public String getAccessToken(String code, String redirectUri) {
+        // form 파라미터를 MultiValueMap으로 구성 — RestClient가 자동으로 form-urlencoded로 직렬화
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("grant_type", "authorization_code");
+
+        GoogleTokenResponse response = restClient.post()
+                .uri(tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                // Google이 4xx/5xx를 반환하면 (잘못된 code, 만료된 code 등) 예외로 변환
+                .onStatus(status -> status.isError(), (req, res) -> {
+                    String body = new String(res.getBody().readAllBytes(), StandardCharsets.UTF_8);
+                    log.error("Google token 교환 실패 — status: {}, body: {}", res.getStatusCode(), body);
+                    throw new AuthException(AuthErrorCode.AUTH_OAUTH_PROVIDER_ERROR);
+                })
+                .body(GoogleTokenResponse.class);
+
+        if (response == null || response.accessToken() == null) {
+            throw new AuthException(AuthErrorCode.AUTH_OAUTH_PROVIDER_ERROR);
+        }
+
+        return response.accessToken();
+    }
+
+    /**
+     * Google access token으로 유저 정보(이메일, 이름)를 조회한다.
+     */
+    public GoogleUserInfoResponse getUserInfo(String googleAccessToken) {
+        GoogleUserInfoResponse response = restClient.get()
+                .uri(userInfoUri)
+                // Google userinfo API는 Bearer 토큰 인증을 요구함
+                .header("Authorization", "Bearer " + googleAccessToken)
+                .retrieve()
+                .onStatus(status -> status.isError(), (req, res) -> {
+                    throw new AuthException(AuthErrorCode.AUTH_OAUTH_PROVIDER_ERROR);
+                })
+                .body(GoogleUserInfoResponse.class);
+
+        if (response == null) {
+            throw new AuthException(AuthErrorCode.AUTH_OAUTH_PROVIDER_ERROR);
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/client/GoogleOAuthClient.java
+++ b/src/main/java/org/sopt/domain/auth/client/GoogleOAuthClient.java
@@ -71,10 +71,6 @@ public class GoogleOAuthClient {
                 + "&scope=email%20profile";
     }
 
-    public String getCallbackUri() {
-        return callbackUri;
-    }
-
     /**
      * authorization code를 Google access token으로 교환한다.
      *

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -85,18 +84,6 @@ public class AuthController {
     public void authorize(HttpServletResponse response) throws IOException {
         // client_id 등 민감한 값을 서버에서 조립해 프론트에 노출하지 않음
         response.sendRedirect(authService.getGoogleAuthorizationUrl());
-    }
-
-    // 프론트엔드가 없는 환경에서 Google OAuth를 테스트하기 위한 콜백 엔드포인트.
-    // 실제 서비스에서는 프론트가 code를 받아 POST /api/v1/auth/google을 호출하므로 이 엔드포인트 불필요.
-    @Operation(summary = "Google OAuth 콜백 (개발용)", hidden = true)
-    @GetMapping("/google/callback")
-    public ResponseEntity<BaseResponse<TokenResponse>> googleCallback(@RequestParam String code) {
-        String redirectUri = authService.getGoogleCallbackUri();
-        TokenResponse tokens = authService.googleLogin(code, redirectUri);
-        return ResponseEntity
-                .status(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS.getHttpStatus())
-                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS, tokens));
     }
 
     @Operation(

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -4,7 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import jakarta.validation.Valid;
+import org.sopt.domain.auth.dto.request.GoogleLoginRequest;
 import org.sopt.domain.auth.dto.request.LoginRequest;
 import org.sopt.domain.auth.dto.request.ReissueRequest;
 import org.sopt.domain.auth.dto.response.TokenResponse;
@@ -14,9 +17,11 @@ import org.sopt.global.response.BaseResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -57,6 +62,41 @@ public class AuthController {
         return ResponseEntity
                 .status(AuthSuccessCode.AUTH_REISSUE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_REISSUE_SUCCESS, tokens));
+    }
+
+    @Operation(
+            summary = "Google 소셜 로그인",
+            description = "Google 인가 코드로 로그인합니다. 신규 유저는 자동으로 회원가입됩니다. " +
+                          "Access Token(30분)과 Refresh Token(2주)을 발급합니다."
+    )
+    @PostMapping("/google")
+    public ResponseEntity<BaseResponse<TokenResponse>> googleLogin(
+            @Valid @RequestBody GoogleLoginRequest request
+    ) {
+        TokenResponse tokens = authService.googleLogin(request.code(), request.redirectUri());
+        return ResponseEntity
+                .status(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS.getHttpStatus())
+                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS, tokens));
+    }
+
+    // ── 개발/테스트 전용 ──────────────────────────────────────────────────────
+    @Operation(summary = "Google 로그인 화면으로 이동 (개발용)", hidden = true)
+    @GetMapping("/google/authorize")
+    public void authorize(HttpServletResponse response) throws IOException {
+        // client_id 등 민감한 값을 서버에서 조립해 프론트에 노출하지 않음
+        response.sendRedirect(authService.getGoogleAuthorizationUrl());
+    }
+
+    // 프론트엔드가 없는 환경에서 Google OAuth를 테스트하기 위한 콜백 엔드포인트.
+    // 실제 서비스에서는 프론트가 code를 받아 POST /api/v1/auth/google을 호출하므로 이 엔드포인트 불필요.
+    @Operation(summary = "Google OAuth 콜백 (개발용)", hidden = true)
+    @GetMapping("/google/callback")
+    public ResponseEntity<BaseResponse<TokenResponse>> googleCallback(@RequestParam String code) {
+        String redirectUri = authService.getGoogleCallbackUri();
+        TokenResponse tokens = authService.googleLogin(code, redirectUri);
+        return ResponseEntity
+                .status(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS.getHttpStatus())
+                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_GOOGLE_LOGIN_SUCCESS, tokens));
     }
 
     @Operation(

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -1,18 +1,22 @@
 package org.sopt.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.sopt.domain.auth.dto.request.LoginRequest;
 import org.sopt.domain.auth.dto.request.ReissueRequest;
 import org.sopt.domain.auth.dto.response.TokenResponse;
 import org.sopt.domain.auth.exception.code.AuthSuccessCode;
 import org.sopt.domain.auth.service.AuthService;
 import org.sopt.global.response.BaseResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Auth", description = "인증 관련 API")
@@ -32,10 +36,9 @@ public class AuthController {
     )
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<TokenResponse>> login(
-            @RequestParam String email,
-            @RequestParam String password
+            @Valid @RequestBody LoginRequest request
     ) {
-        TokenResponse tokens = authService.login(email, password);
+        TokenResponse tokens = authService.login(request.email(), request.password());
         return ResponseEntity
                 .status(AuthSuccessCode.AUTH_LOGIN_SUCCESS.getHttpStatus())
                 .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_LOGIN_SUCCESS, tokens));
@@ -54,5 +57,31 @@ public class AuthController {
         return ResponseEntity
                 .status(AuthSuccessCode.AUTH_REISSUE_SUCCESS.getHttpStatus())
                 .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_REISSUE_SUCCESS, tokens));
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "DB에서 Refresh Token을 삭제하고, 현재 Access Token을 블랙리스트에 등록합니다. " +
+                          "블랙리스트에 등록된 토큰은 만료 전이라도 사용할 수 없습니다."
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(
+            Authentication authentication,
+            HttpServletRequest request
+    ) {
+        Long userId = Long.parseLong(authentication.getName());
+
+        // "Bearer " 접두사를 제거해 순수 토큰 문자열만 추출
+        // JwtAuthFilter에서 이미 검증된 토큰이므로 여기서는 파싱만 수행
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION)
+                .substring("Bearer ".length())
+                .trim();
+
+        authService.logout(userId, accessToken);
+
+        return ResponseEntity
+                .status(AuthSuccessCode.AUTH_LOGOUT_SUCCESS.getHttpStatus())
+                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_LOGOUT_SUCCESS, null));
     }
 }

--- a/src/main/java/org/sopt/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/domain/auth/controller/AuthController.java
@@ -1,0 +1,58 @@
+package org.sopt.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.sopt.domain.auth.dto.request.ReissueRequest;
+import org.sopt.domain.auth.dto.response.TokenResponse;
+import org.sopt.domain.auth.exception.code.AuthSuccessCode;
+import org.sopt.domain.auth.service.AuthService;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호로 로그인합니다. Access Token(30분)과 Refresh Token(2주)을 발급합니다."
+    )
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<TokenResponse>> login(
+            @RequestParam String email,
+            @RequestParam String password
+    ) {
+        TokenResponse tokens = authService.login(email, password);
+        return ResponseEntity
+                .status(AuthSuccessCode.AUTH_LOGIN_SUCCESS.getHttpStatus())
+                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_LOGIN_SUCCESS, tokens));
+    }
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "만료된 Access Token을 Refresh Token으로 재발급합니다. " +
+                          "Refresh Token Rotation 방식으로 Refresh Token도 함께 교체됩니다."
+    )
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<TokenResponse>> reissue(
+            @Valid @RequestBody ReissueRequest request
+    ) {
+        TokenResponse tokens = authService.reissue(request.refreshToken());
+        return ResponseEntity
+                .status(AuthSuccessCode.AUTH_REISSUE_SUCCESS.getHttpStatus())
+                .body(BaseResponse.onSuccess(AuthSuccessCode.AUTH_REISSUE_SUCCESS, tokens));
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/org/sopt/domain/auth/dto/request/GoogleLoginRequest.java
@@ -1,0 +1,19 @@
+package org.sopt.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Google 소셜 로그인 요청")
+public record GoogleLoginRequest(
+        // 클라이언트가 Google 인가 화면에서 받은 authorization code
+        // 1회성이며 수 분 내 만료됨 — 서버가 이 코드로 Google에서 access token을 교환함
+        @Schema(description = "Google 인가 코드", example = "4/0AX4XfWh...")
+        @NotBlank(message = "인가 코드는 필수입니다.")
+        String code,
+
+        // 클라이언트가 Google에 등록한 redirect URI와 반드시 일치해야 함
+        // Google이 code를 발급할 때 사용한 redirect URI를 token 교환 시 재검증함
+        @Schema(description = "Google OAuth redirect URI", example = "http://localhost:3000/oauth/callback")
+        @NotBlank(message = "redirect URI는 필수입니다.")
+        String redirectUri
+) {}

--- a/src/main/java/org/sopt/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/sopt/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package org.sopt.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청")
+public record LoginRequest(
+        // 이메일·비밀번호를 @RequestParam(쿼리스트링)으로 받으면
+        // 서버 액세스 로그, 브라우저 히스토리, 프록시 로그에 평문이 그대로 남음
+        // @RequestBody로 받아야 HTTPS 암호화 페이로드에 포함되어 노출되지 않음
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password123")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/org/sopt/domain/auth/dto/request/ReissueRequest.java
+++ b/src/main/java/org/sopt/domain/auth/dto/request/ReissueRequest.java
@@ -1,0 +1,12 @@
+package org.sopt.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "토큰 재발급 요청")
+public record ReissueRequest(
+    // 토큰을 URL 파라미터로 보내면 서버 로그·브라우저 히스토리에 노출될 수 있어 body 전송이 원칙
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    @NotBlank(message = "Refresh Token은 필수입니다.")
+    String refreshToken
+) {}

--- a/src/main/java/org/sopt/domain/auth/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/org/sopt/domain/auth/dto/response/GoogleTokenResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Google token endpoint가 반환하는 응답 중 우리가 필요한 필드만 매핑
+// Google은 snake_case를 사용하므로 @JsonProperty로 매핑
+public record GoogleTokenResponse(
+        @JsonProperty("access_token") String accessToken
+) {}

--- a/src/main/java/org/sopt/domain/auth/dto/response/GoogleUserInfoResponse.java
+++ b/src/main/java/org/sopt/domain/auth/dto/response/GoogleUserInfoResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.domain.auth.dto.response;
+
+// Google userinfo endpoint가 반환하는 응답 중 필요한 필드만 매핑
+// id: Google 계정 고유 식별자 (providerId로 활용 가능)
+// email, name: 유저 생성에 사용
+public record GoogleUserInfoResponse(
+        String id,
+        String email,
+        String name
+) {}

--- a/src/main/java/org/sopt/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/sopt/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 응답")
+public record TokenResponse(
+        @Schema(description = "Access Token (30분 유효)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String accessToken,
+
+        @Schema(description = "Refresh Token (2주 유효)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String refreshToken
+) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,63 @@
+package org.sopt.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    // 토큰 값 자체는 유일해야 조회/무효화가 정확함
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    protected RefreshToken() {}
+
+    private RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    public static RefreshToken of(Long userId, String token, long expiresInSeconds) {
+        return new RefreshToken(
+                userId,
+                token,
+                LocalDateTime.now().plusSeconds(expiresInSeconds)
+        );
+    }
+
+    /**
+     * Refresh Token Rotation: 재발급 시 동일 row를 업데이트해 항상 유저당 토큰 1개를 유지
+     * 새 row를 INSERT하지 않으므로 userId UNIQUE 제약 없이도 중복 발급 방지 효과
+     */
+    public void rotate(String newToken, long expiresInSeconds) {
+        this.token = newToken;
+        this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSeconds);
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/exception/AuthException.java
+++ b/src/main/java/org/sopt/domain/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package org.sopt.domain.auth.exception;
+
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.code.BaseErrorCode;
+
+public class AuthException extends CustomException {
+
+    public AuthException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/sopt/domain/auth/exception/code/AuthErrorCode.java
@@ -1,0 +1,41 @@
+package org.sopt.domain.auth.exception.code;
+
+import org.sopt.global.exception.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements BaseErrorCode {
+
+    // Spring Security 필터 단에서 발생 — GlobalExceptionHandler가 아닌 EntryPoint/Handler가 처리
+    AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH4010", "인증이 필요합니다."),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH4030", "접근 권한이 없습니다."),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH4011", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4012", "회원이 존재하지 않습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4013", "유효하지 않은 토큰입니다."),
+    // 토큰이 만료/위변조된 경우와 구별 — DB에서 이미 삭제된(로그아웃/재발급된) 토큰
+    AUTH_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4014", "Refresh Token이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/org/sopt/domain/auth/exception/code/AuthErrorCode.java
@@ -12,7 +12,9 @@ public enum AuthErrorCode implements BaseErrorCode {
     AUTH_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4012", "회원이 존재하지 않습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4013", "유효하지 않은 토큰입니다."),
     // 토큰이 만료/위변조된 경우와 구별 — DB에서 이미 삭제된(로그아웃/재발급된) 토큰
-    AUTH_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4014", "Refresh Token이 존재하지 않습니다.");
+    AUTH_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH4014", "Refresh Token이 존재하지 않습니다."),
+    // Google 인가 코드가 유효하지 않거나 이미 사용된 경우
+    AUTH_OAUTH_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "AUTH4015", "Google 인증 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
@@ -1,0 +1,35 @@
+package org.sopt.domain.auth.exception.code;
+
+import org.sopt.global.exception.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthSuccessCode implements BaseSuccessCode {
+
+    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인에 성공했습니다."),
+    AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2002", "토큰 재발급에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    AuthSuccessCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
@@ -7,7 +7,8 @@ public enum AuthSuccessCode implements BaseSuccessCode {
 
     AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인에 성공했습니다."),
     AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2002", "토큰 재발급에 성공했습니다."),
-    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃에 성공했습니다.");
+    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃에 성공했습니다."),
+    AUTH_GOOGLE_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2004", "Google 로그인에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
+++ b/src/main/java/org/sopt/domain/auth/exception/code/AuthSuccessCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum AuthSuccessCode implements BaseSuccessCode {
 
     AUTH_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인에 성공했습니다."),
-    AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2002", "토큰 재발급에 성공했습니다.");
+    AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH2002", "토큰 재발급에 성공했습니다."),
+    AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/sopt/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.domain.auth.repository;
+
+import java.util.Optional;
+import org.sopt.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -144,10 +144,6 @@ public class AuthService {
         return googleOAuthClient.buildAuthorizationUrl();
     }
 
-    public String getGoogleCallbackUri() {
-        return googleOAuthClient.getCallbackUri();
-    }
-
     @Transactional
     public TokenResponse googleLogin(String code, String redirectUri) {
         // 1단계: authorization code → Google access token

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -2,11 +2,14 @@ package org.sopt.domain.auth.service;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import java.time.Instant;
+import org.sopt.domain.auth.client.GoogleOAuthClient;
+import org.sopt.domain.auth.dto.response.GoogleUserInfoResponse;
 import org.sopt.domain.auth.dto.response.TokenResponse;
 import org.sopt.domain.auth.entity.RefreshToken;
 import org.sopt.domain.auth.exception.AuthException;
 import org.sopt.domain.auth.exception.code.AuthErrorCode;
 import org.sopt.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.domain.user.entity.AuthProvider;
 import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.repository.UserRepository;
 import org.sopt.global.jwt.AccessTokenBlacklistService;
@@ -24,6 +27,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
     private final AccessTokenBlacklistService blacklistService;
+    private final GoogleOAuthClient googleOAuthClient;
 
     // 타이밍 공격 방지용 더미 해시
     // 이메일이 존재하지 않는 경우에도 BCrypt 연산을 동일하게 실행해 응답 시간을 일정하게 만듦
@@ -38,13 +42,15 @@ public class AuthService {
             RefreshTokenRepository refreshTokenRepository,
             JwtService jwtService,
             PasswordEncoder passwordEncoder,
-            AccessTokenBlacklistService blacklistService
+            AccessTokenBlacklistService blacklistService,
+            GoogleOAuthClient googleOAuthClient
     ) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtService = jwtService;
         this.passwordEncoder = passwordEncoder;
         this.blacklistService = blacklistService;
+        this.googleOAuthClient = googleOAuthClient;
         this.dummyHash = passwordEncoder.encode(java.util.UUID.randomUUID().toString());
     }
 
@@ -63,7 +69,9 @@ public class AuthService {
         // 이메일 존재 여부와 무관하게 항상 BCrypt를 실행해 응답 시간을 동일하게 만든다.
         User user = userRepository.findByEmail(email).orElse(null);
 
-        String hashToCompare = (user != null) ? user.getPassword() : dummyHash;
+        // OAuth 유저(password == null)도 dummyHash로 처리해 항상 BCrypt를 실행
+        // → 타이밍 공격 방지 유지, OAuth 유저의 이메일/비밀번호 로그인 시도 차단
+        String hashToCompare = (user != null && user.getPassword() != null) ? user.getPassword() : dummyHash;
 
         // matches(입력된 평문, DB의 BCrypt 해시)
         // BCrypt 해시 안에 솔트가 내장되어 있어 matches()가 솔트 추출 → 재해시 → 비교를 자동 처리
@@ -117,6 +125,54 @@ public class AuthService {
         // 만료 시각을 함께 저장해 두면 스케줄러가 만료된 항목을 주기적으로 정리할 수 있음
         Instant expiresAt = jwtService.getExpiry(accessToken);
         blacklistService.blacklist(accessToken, expiresAt);
+    }
+
+    /**
+     * Google OAuth 2.0 소셜 로그인.
+     *
+     * ── 흐름 ────────────────────────────────────────────────────────────────
+     * 1. 클라이언트로부터 받은 authorization code로 Google access token 교환
+     * 2. Google access token으로 유저 정보(이메일, 이름) 조회
+     * 3. 이메일로 기존 유저 조회 — 없으면 자동 회원가입(신규 유저 생성)
+     * 4. 우리 서버의 JWT 발급 후 반환
+     *
+     * ── 신규 vs 기존 유저 판별 ────────────────────────────────────────────
+     * 이메일을 기준으로 판별한다. 동일 이메일로 LOCAL 회원가입한 유저가 Google 로그인을
+     * 시도하면 같은 계정으로 로그인된다 (이메일 기반 계정 병합).
+     */
+    public String getGoogleAuthorizationUrl() {
+        return googleOAuthClient.buildAuthorizationUrl();
+    }
+
+    public String getGoogleCallbackUri() {
+        return googleOAuthClient.getCallbackUri();
+    }
+
+    @Transactional
+    public TokenResponse googleLogin(String code, String redirectUri) {
+        // 1단계: authorization code → Google access token
+        String googleAccessToken = googleOAuthClient.getAccessToken(code, redirectUri);
+
+        // 2단계: Google access token → 유저 정보
+        GoogleUserInfoResponse userInfo = googleOAuthClient.getUserInfo(googleAccessToken);
+
+        // 3단계: 이메일로 기존 유저 조회, 없으면 신규 생성
+        // orElseGet: 유저가 없을 때만 람다 실행 — save 쿼리가 불필요하게 실행되지 않음
+        User user = userRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> userRepository.save(
+                        User.ofOAuth(userInfo.name(), userInfo.email(), AuthProvider.GOOGLE)
+                ));
+
+        // 4단계: JWT 발급 (로그인과 동일한 로직)
+        String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtService.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(
+                RefreshToken.of(user.getId(), refreshToken, refreshTokenExpiresInSeconds)
+        );
+
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
     /**

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package org.sopt.domain.auth.service;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import java.time.Instant;
 import org.sopt.domain.auth.dto.response.TokenResponse;
 import org.sopt.domain.auth.entity.RefreshToken;
 import org.sopt.domain.auth.exception.AuthException;
@@ -8,6 +9,7 @@ import org.sopt.domain.auth.exception.code.AuthErrorCode;
 import org.sopt.domain.auth.repository.RefreshTokenRepository;
 import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.global.jwt.AccessTokenBlacklistService;
 import org.sopt.global.jwt.JwtService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,6 +23,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtService jwtService;
     private final PasswordEncoder passwordEncoder;
+    private final AccessTokenBlacklistService blacklistService;
 
     // 타이밍 공격 방지용 더미 해시
     // 이메일이 존재하지 않는 경우에도 BCrypt 연산을 동일하게 실행해 응답 시간을 일정하게 만듦
@@ -34,12 +37,14 @@ public class AuthService {
             UserRepository userRepository,
             RefreshTokenRepository refreshTokenRepository,
             JwtService jwtService,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            AccessTokenBlacklistService blacklistService
     ) {
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.jwtService = jwtService;
         this.passwordEncoder = passwordEncoder;
+        this.blacklistService = blacklistService;
         this.dummyHash = passwordEncoder.encode(java.util.UUID.randomUUID().toString());
     }
 
@@ -78,6 +83,40 @@ public class AuthService {
         );
 
         return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    /**
+     * 로그아웃: Refresh Token을 DB에서 삭제하고, Access Token을 블랙리스트에 등록한다.
+     *
+     * ── Refresh Token 삭제 ──────────────────────────────────────────────────
+     * DB에서 해당 유저의 Refresh Token을 제거해 재발급 경로를 차단한다.
+     * Refresh Token이 없더라도 에러를 던지지 않음 — 이미 로그아웃된 상태를 멱등(idempotent)하게 처리.
+     *
+     * ── Access Token 블랙리스트 ─────────────────────────────────────────────
+     * JWT는 stateless라 서버가 단독으로 무효화할 수 없다.
+     * 만료 전 토큰을 무력화하려면 서버 측에서 사용 금지 목록을 관리해야 한다.
+     * JwtAuthFilter가 매 요청마다 블랙리스트를 확인해 등록된 토큰을 차단한다.
+     *
+     * ── 클라이언트가 401을 감지해 로그인 페이지로 이동하는 흐름 ───────────────
+     * 1. 클라이언트가 API를 호출한다 (Access Token을 Authorization 헤더에 포함).
+     * 2. 서버가 401 (AUTH4010) 을 반환한다.
+     *    - Access Token 만료: JWTVerificationException → SecurityContext 미설정 → 401
+     *    - 블랙리스트 등록된 토큰: JwtAuthFilter에서 SecurityContext 미설정 → 401
+     * 3. 클라이언트는 401을 받으면 저장된 Refresh Token으로 /api/v1/auth/reissue를 호출한다.
+     * 4-a. 재발급 성공(200): 새 Access/Refresh Token을 저장하고 원래 요청을 재시도한다.
+     * 4-b. 재발급 실패(401): Refresh Token도 만료되었거나 로그아웃으로 삭제된 경우.
+     *      저장된 토큰을 모두 제거하고 로그인 페이지로 이동시킨다.
+     */
+    @Transactional
+    public void logout(Long userId, String accessToken) {
+        // Refresh Token 삭제 — 이미 없어도 예외 없이 정상 처리 (멱등성 보장)
+        refreshTokenRepository.deleteByUserId(userId);
+
+        // Access Token 블랙리스트 등록
+        // getExpiry()는 JWT 서명을 다시 검증하므로 위변조된 토큰을 그대로 등록하는 위험이 없음
+        // 만료 시각을 함께 저장해 두면 스케줄러가 만료된 항목을 주기적으로 정리할 수 있음
+        Instant expiresAt = jwtService.getExpiry(accessToken);
+        blacklistService.blacklist(accessToken, expiresAt);
     }
 
     /**

--- a/src/main/java/org/sopt/domain/auth/service/AuthService.java
+++ b/src/main/java/org/sopt/domain/auth/service/AuthService.java
@@ -1,0 +1,117 @@
+package org.sopt.domain.auth.service;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import org.sopt.domain.auth.dto.response.TokenResponse;
+import org.sopt.domain.auth.entity.RefreshToken;
+import org.sopt.domain.auth.exception.AuthException;
+import org.sopt.domain.auth.exception.code.AuthErrorCode;
+import org.sopt.domain.auth.repository.RefreshTokenRepository;
+import org.sopt.domain.user.entity.User;
+import org.sopt.domain.user.repository.UserRepository;
+import org.sopt.global.jwt.JwtService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+
+    // 타이밍 공격 방지용 더미 해시
+    // 이메일이 존재하지 않는 경우에도 BCrypt 연산을 동일하게 실행해 응답 시간을 일정하게 만듦
+    // 서버 시작 시 한 번만 생성되며, 임의값을 해시했으므로 실제 비밀번호와 절대 일치하지 않음
+    private final String dummyHash;
+
+    @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
+    private long refreshTokenExpiresInSeconds;
+
+    public AuthService(
+            UserRepository userRepository,
+            RefreshTokenRepository refreshTokenRepository,
+            JwtService jwtService,
+            PasswordEncoder passwordEncoder
+    ) {
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
+        this.dummyHash = passwordEncoder.encode(java.util.UUID.randomUUID().toString());
+    }
+
+    /**
+     * 이메일·비밀번호 검증 후 Access Token + Refresh Token을 반환한다.
+     *
+     * Refresh Token은 DB에 1개만 유지:
+     * 로그인할 때마다 기존 토큰을 삭제하고 새로 저장하여
+     * 다른 기기·세션에서 발급된 이전 토큰을 자동 무효화한다.
+     */
+    @Transactional
+    public TokenResponse login(String email, String password) {
+        // orElse(null) 사용 이유:
+        // orElseThrow()를 쓰면 이메일 없을 때 BCrypt를 건너뛰어 응답이 즉시 반환됨.
+        // 이메일 있고 비밀번호 틀릴 때는 BCrypt가 ~100ms 걸려 응답 시간 차이로 이메일 존재 여부가 노출됨(타이밍 공격).
+        // 이메일 존재 여부와 무관하게 항상 BCrypt를 실행해 응답 시간을 동일하게 만든다.
+        User user = userRepository.findByEmail(email).orElse(null);
+
+        String hashToCompare = (user != null) ? user.getPassword() : dummyHash;
+
+        // matches(입력된 평문, DB의 BCrypt 해시)
+        // BCrypt 해시 안에 솔트가 내장되어 있어 matches()가 솔트 추출 → 재해시 → 비교를 자동 처리
+        // equals()로 비교 x — 솔트 때문에 동일 비밀번호도 해시값이 매번 다름
+        // 이메일 없음·비밀번호 불일치 모두 동일한 에러 코드 반환
+        // → 어느 값이 틀렸는지 응답만으로 구분 불가
+        if (user == null || !passwordEncoder.matches(password, hashToCompare)) {
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtService.generateRefreshToken(user.getId());
+
+        refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.save(
+                RefreshToken.of(user.getId(), refreshToken, refreshTokenExpiresInSeconds)
+        );
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    /**
+     * Refresh Token으로 Access Token + Refresh Token을 재발급한다 (Rotation 방식).
+     *
+     * Rotation이란: 재발급 때마다 Refresh Token 자체도 교체하는 전략.
+     * 탈취된 Refresh Token이 공격자에 의해 한 번 사용되면 DB 토큰이 바뀌므로,
+     * 이후 피해자의 재발급 요청이 실패하여 침해를 감지할 수 있다.
+     */
+    @Transactional
+    public TokenResponse reissue(String rawRefreshToken) {
+        // 1단계: JWT 서명·만료 검증 (위변조·만료 → AUTH_INVALID_TOKEN)
+        Long userId;
+        try {
+            userId = jwtService.verifyAndGetUserId(rawRefreshToken);
+        } catch (JWTVerificationException | IllegalArgumentException e) {
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        // 2단계: DB 조회 — JWT가 유효하더라도 이미 로그아웃하거나 재발급된 토큰이면 거부
+        // (JWT는 stateless라 서버가 단독으로 무효화할 수 없어, DB가 서버 측 revocation 역할을 함)
+        RefreshToken storedToken = refreshTokenRepository.findByToken(rawRefreshToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_REFRESH_TOKEN_NOT_FOUND));
+
+        // 3단계: 새 토큰 발급
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.AUTH_USER_NOT_FOUND));
+
+        String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+        String newRefreshToken = jwtService.generateRefreshToken(user.getId());
+
+        // 4단계: Rotation — 기존 row를 UPDATE하여 DB에는 항상 유저당 토큰 1개만 존재
+        storedToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/org/sopt/domain/like/controller/LikeController.java
+++ b/src/main/java/org/sopt/domain/like/controller/LikeController.java
@@ -1,20 +1,17 @@
 package org.sopt.domain.like.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import org.sopt.domain.like.dto.request.LikeRequest;
 import org.sopt.domain.like.exception.code.LikeSuccessCode;
 import org.sopt.domain.like.service.LikeService;
 import org.sopt.global.response.BaseResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Like", description = "좋아요 관련 API")
@@ -28,24 +25,30 @@ public class LikeController {
     this.likeService = likeService;
   }
 
-  @Operation(summary = "좋아요 추가", description = "특정 게시글에 좋아요를 누릅니다. 같은 게시글에 중복 좋아요는 불가합니다.")
+  @Operation(summary = "좋아요 추가", description = "Access Token으로 인증된 유저가 특정 게시글에 좋아요를 누릅니다.")
+  @SecurityRequirement(name = "bearerAuth")
   @PostMapping
   public ResponseEntity<BaseResponse<Void>> addLike(
       @PathVariable Long postId,
-      @Valid @RequestBody LikeRequest request
+      Authentication authentication
   ) {
-    likeService.addLike(postId, request.userId());
+    // userId를 요청 바디/파라미터로 받지 않고 JWT에서 추출
+    // → 클라이언트가 타인의 userId로 좋아요 위장하는 것을 방지
+    Long userId = Long.parseLong(authentication.getName());
+    likeService.addLike(postId, userId);
     return ResponseEntity
         .status(LikeSuccessCode.LIKE_SUCCESS.getHttpStatus())
         .body(BaseResponse.onSuccess(LikeSuccessCode.LIKE_SUCCESS, null));
   }
 
-  @Operation(summary = "좋아요 취소", description = "특정 게시글에 누른 좋아요를 취소합니다.")
+  @Operation(summary = "좋아요 취소", description = "Access Token으로 인증된 유저가 특정 게시글의 좋아요를 취소합니다.")
+  @SecurityRequirement(name = "bearerAuth")
   @DeleteMapping
   public ResponseEntity<BaseResponse<Void>> cancelLike(
       @PathVariable Long postId,
-      @NotNull @RequestParam Long userId
+      Authentication authentication
   ) {
+    Long userId = Long.parseLong(authentication.getName());
     likeService.cancelLike(postId, userId);
     return ResponseEntity
         .status(LikeSuccessCode.LIKE_CANCEL_SUCCESS.getHttpStatus())

--- a/src/main/java/org/sopt/domain/like/service/LikeService.java
+++ b/src/main/java/org/sopt/domain/like/service/LikeService.java
@@ -11,7 +11,6 @@ import org.sopt.domain.post.repository.PostRepository;
 import org.sopt.domain.user.entity.User;
 import org.sopt.domain.user.repository.UserRepository;
 import org.sopt.global.exception.CustomException;
-import org.sopt.global.exception.code.GlobalErrorCode;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
@@ -49,20 +48,23 @@ public class LikeService {
   )
   @Transactional
   public void addLike(Long postId, Long userId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(GlobalErrorCode.COMMON_BAD_REQUEST));
-
-    // version 필드가 있는 Post를 로딩 — 이 시점의 version이 커밋 시 기준값이 된다
-    Post post = postRepository.findById(postId)
-        .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
+    // ① 중복 체크를 가장 먼저: 이미 좋아요를 눌렀다면 Post/User 조회 없이 즉시 예외
     if (likeRepository.existsByUserIdAndPostId(userId, postId)) {
       throw new LikeException(LikeErrorCode.LIKE_ALREADY_EXISTS);
     }
 
+    // ② version 필드가 있는 Post 로딩 — 이 시점의 version이 커밋 시 기준값이 된다
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+    // ③ getReferenceById: SELECT 없이 userId를 ID로 가진 프록시 반환
+    // JWT 필터를 통과한 userId는 서버가 이미 검증한 값이므로 실제 존재가 보장됨
+    // findById()는 User 데이터 전체를 SELECT하지만, Like 저장에는 FK(user_id) 값만 필요
+    User user = userRepository.getReferenceById(userId);
+
     likeRepository.save(new Like(user, post));
-    // likeCount 변경 → JPA가 Post를 dirty 감지 → UPDATE post SET like_count=?, version=? WHERE id=? AND version=?
-    // 다른 트랜잭션이 먼저 커밋했다면 WHERE version=? 조건 불일치 → OptimisticLockingFailureException
+    // likeCount 변경 → JPA dirty 감지 → UPDATE post SET like_count=?, version=? WHERE id=? AND version=?
+    // 다른 트랜잭션이 먼저 커밋했다면 version 불일치 → OptimisticLockingFailureException
     post.incrementLikeCount();
   }
 

--- a/src/main/java/org/sopt/domain/post/controller/PostController.java
+++ b/src/main/java/org/sopt/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package org.sopt.domain.post.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.sopt.domain.post.dto.request.CreatePostRequest;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post", description = "게시글 관련 API")
-@Validated  // @RequestParam의 @NotBlank 등 제약 어노테이션을 활성화 (@Valid는 @RequestBody에만 동작)
+@Validated
 @RestController
 @RequestMapping("/api/v1/posts")
 public class PostController {
@@ -39,12 +41,17 @@ public class PostController {
     this.postService = postService;
   }
 
-  @Operation(summary = "게시글 생성", description = "userId를 받아 새로운 게시글을 작성합니다.")
+  @Operation(summary = "게시글 생성", description = "Access Token으로 인증된 유저가 새로운 게시글을 작성합니다.")
+  @SecurityRequirement(name = "bearerAuth")
   @PostMapping
   public ResponseEntity<BaseResponse<PostResponse>> createPost(
-      @Valid @RequestBody CreatePostRequest request
+      @Valid @RequestBody CreatePostRequest request,
+      Authentication authentication
   ) {
-    PostResponse response = postService.createPost(request);
+    // SecurityConfig에서 POST /api/v1/posts는 authenticated() 대상이므로
+    // 이 시점에 authentication은 항상 유효한 JWT에서 추출된 값
+    Long userId = extractUserId(authentication);
+    PostResponse response = postService.createPost(userId, request);
 
     return ResponseEntity
         .status(PostSuccessCode.POST_CREATE_SUCCESS.getHttpStatus())
@@ -74,13 +81,16 @@ public class PostController {
         .body(BaseResponse.onSuccess(PostSuccessCode.POST_GET_SUCCESS, response));
   }
 
-  @Operation(summary = "게시글 수정", description = "기존 게시글의 제목과 내용을 수정합니다.")
+  @Operation(summary = "게시글 수정", description = "자신이 작성한 게시글의 제목과 내용을 수정합니다.")
+  @SecurityRequirement(name = "bearerAuth")
   @PutMapping("/{id}")
   public ResponseEntity<BaseResponse<PostResponse>> updatePost(
       @PathVariable Long id,
-      @Valid @RequestBody UpdatePostRequest request
+      @Valid @RequestBody UpdatePostRequest request,
+      Authentication authentication
   ) {
-    PostResponse response = postService.updatePost(id, request);
+    Long userId = extractUserId(authentication);
+    PostResponse response = postService.updatePost(id, userId, request);
     return ResponseEntity
         .status(PostSuccessCode.POST_UPDATE_SUCCESS.getHttpStatus())
         .body(BaseResponse.onSuccess(PostSuccessCode.POST_UPDATE_SUCCESS, response));
@@ -103,14 +113,22 @@ public class PostController {
         .body(BaseResponse.onSuccess(PostSuccessCode.POST_SEARCH_SUCCESS, response));
   }
 
-  @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+  @Operation(summary = "게시글 삭제", description = "자신이 작성한 게시글을 삭제합니다.")
+  @SecurityRequirement(name = "bearerAuth")
   @DeleteMapping("/{id}")
   public ResponseEntity<BaseResponse<Void>> deletePost(
-      @PathVariable Long id
+      @PathVariable Long id,
+      Authentication authentication
   ) {
-    postService.deletePost(id);
+    Long userId = extractUserId(authentication);
+    postService.deletePost(id, userId);
     return ResponseEntity
         .status(PostSuccessCode.POST_DELETE_SUCCESS.getHttpStatus())
         .body(BaseResponse.onSuccess(PostSuccessCode.POST_DELETE_SUCCESS, null));
+  }
+
+  // JWT 필터가 principal에 userId(String)를 저장하므로 getName()으로 꺼낸 뒤 Long으로 파싱
+  private Long extractUserId(Authentication authentication) {
+    return Long.parseLong(authentication.getName());
   }
 }

--- a/src/main/java/org/sopt/domain/post/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/domain/post/dto/request/CreatePostRequest.java
@@ -17,10 +17,6 @@ public record CreatePostRequest(
     @NotBlank(message = "내용을 입력해주세요.")
     String content,
 
-    @Schema(description = "작성자 ID", example = "1")
-    @NotNull(message = "작성자 ID는 필수입니다.")
-    Long userId,
-
     @Schema(description = "게시판 종류", example = "FREE")
     @NotNull(message = "게시판 종류는 필수입니다.")
     BoardType boardType

--- a/src/main/java/org/sopt/domain/post/exception/code/PostErrorCode.java
+++ b/src/main/java/org/sopt/domain/post/exception/code/PostErrorCode.java
@@ -7,10 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements BaseErrorCode {
 
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4041", "해당 게시글을 찾을 수 없습니다."),
+  // 인증은 됐지만 자기 글이 아닌 경우 — 401(미인증)과 구분하기 위해 403 사용
+  POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST4031", "해당 게시글에 대한 권한이 없습니다."),
   POST_BAD_REQUEST(HttpStatus.BAD_REQUEST, "POST4000", "잘못된 게시글 요청입니다."),
   POST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4001", "제목은 필수 입력 항목입니다."),
   POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST4002", "내용을 입력해주세요."),
-  POST_AUTHOR_REQUIRED(HttpStatus.BAD_REQUEST, "POST4003", "작성자 ID는 필수입니다."),
   POST_BOARD_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4004", "게시판 종류는 필수입니다."),
   POST_SEARCH_KEYWORD_REQUIRED(HttpStatus.BAD_REQUEST, "POST4005", "검색어를 입력해주세요.");
 

--- a/src/main/java/org/sopt/domain/post/service/PostService.java
+++ b/src/main/java/org/sopt/domain/post/service/PostService.java
@@ -1,12 +1,12 @@
 package org.sopt.domain.post.service;
 
 import java.util.List;
+import org.sopt.domain.post.dto.request.CreatePostRequest;
 import org.sopt.domain.post.dto.request.UpdatePostRequest;
 import org.sopt.domain.post.dto.response.PostPageResponse;
+import org.sopt.domain.post.dto.response.PostResponse;
 import org.sopt.domain.post.entity.BoardType;
 import org.sopt.domain.post.entity.Post;
-import org.sopt.domain.post.dto.request.CreatePostRequest;
-import org.sopt.domain.post.dto.response.PostResponse;
 import org.sopt.domain.post.exception.PostException;
 import org.sopt.domain.post.exception.code.PostErrorCode;
 import org.sopt.domain.post.repository.PostRepository;
@@ -31,8 +31,9 @@ public class PostService {
   }
 
   @Transactional
-  public PostResponse createPost(CreatePostRequest request) {
-    User user = userRepository.findById(request.userId())
+  public PostResponse createPost(Long userId, CreatePostRequest request) {
+    // userId는 컨트롤러에서 JWT로 검증된 값 — 클라이언트 입력값 아님
+    User user = userRepository.findById(userId)
         .orElseThrow(() -> new CustomException(GlobalErrorCode.COMMON_BAD_REQUEST));
 
     Post savedPost = postRepository.save(new Post(
@@ -45,8 +46,6 @@ public class PostService {
     return PostResponse.from(savedPost);
   }
 
-  // Pageable은 컨트롤러에서 Spring이 만들어주고, Repository에 그대로 넘겨 DB 레벨에서 정렬/페이징 처리
-  // likeCount는 Post 엔티티에 비정규화되어 있으므로 별도 COUNT 쿼리 없이 JOIN FETCH 1번으로 해결
   @Transactional(readOnly = true)
   public PostPageResponse getPosts(BoardType boardType, Pageable pageable) {
     Page<Post> postPage = (boardType != null)
@@ -72,28 +71,32 @@ public class PostService {
   public PostResponse getPost(Long id) {
     Post post = postRepository.findByIdWithUser(id)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
     return PostResponse.from(post);
   }
 
   @Transactional
-  public PostResponse updatePost(Long id, UpdatePostRequest request) {
-    Post post = postRepository.findByIdWithUser(id)
+  public PostResponse updatePost(Long postId, Long userId, UpdatePostRequest request) {
+    Post post = postRepository.findByIdWithUser(postId)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+    // 인증(Authentication) ≠ 인가(Authorization)
+    // JWT 검증으로 "누구인지"는 확인했지만, "이 게시글을 수정할 권한이 있는지"는 별도로 확인해야 함
+    validateOwnership(post, userId);
 
     post.update(request.title(), request.content());
     return PostResponse.from(post);
   }
 
   @Transactional
-  public void deletePost(Long id) {
-    Post post = postRepository.findById(id)
+  public void deletePost(Long postId, Long userId) {
+    // findByIdWithUser: user JOIN FETCH — 소유권 체크를 위해 user 필드가 필요
+    Post post = postRepository.findByIdWithUser(postId)
         .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
+    validateOwnership(post, userId);
     postRepository.delete(post);
   }
 
-  // titleKeyword, authorNickname 모두 null/빈 문자열 허용 — QueryDSL이 동적으로 조건을 조합
   @Transactional(readOnly = true)
   public PostPageResponse searchPosts(String titleKeyword, String authorNickname, Pageable pageable) {
     Page<Post> postPage = postRepository.searchDynamically(titleKeyword, authorNickname, pageable);
@@ -111,5 +114,13 @@ public class PostService {
         postPage.isFirst(),
         postPage.isLast()
     );
+  }
+
+  // 게시글 작성자와 요청자가 다르면 403 Forbidden
+  // POST_NOT_FOUND(404)보다 먼저 호출되므로, 존재하지 않는 글이면 이 메서드 이전에 이미 예외가 발생함
+  private void validateOwnership(Post post, Long userId) {
+    if (!post.getUser().getId().equals(userId)) {
+      throw new PostException(PostErrorCode.POST_FORBIDDEN);
+    }
   }
 }

--- a/src/main/java/org/sopt/domain/user/controller/UserController.java
+++ b/src/main/java/org/sopt/domain/user/controller/UserController.java
@@ -1,0 +1,62 @@
+package org.sopt.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.sopt.domain.user.dto.request.CreateUserRequest;
+import org.sopt.domain.user.dto.response.CreateUserResponse;
+import org.sopt.domain.user.dto.response.UserResponse;
+import org.sopt.domain.user.exception.UserException;
+import org.sopt.domain.user.exception.code.UserErrorCode;
+import org.sopt.domain.user.exception.code.UserSuccessCode;
+import org.sopt.domain.user.service.UserService;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저 관련 API")
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+  private final UserService userService;
+
+  public UserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Operation(summary = "회원 가입", description = "닉네임, 이메일, 비밀번호를 받아 새로운 유저를 생성합니다.")
+  @PostMapping
+  public ResponseEntity<BaseResponse<CreateUserResponse>> join(
+      @Valid @RequestBody CreateUserRequest request
+  ) {
+    CreateUserResponse response = userService.join(request);
+    return ResponseEntity
+        .status(UserSuccessCode.USER_JOIN_SUCCESS.getHttpStatus())
+        .body(BaseResponse.onSuccess(UserSuccessCode.USER_JOIN_SUCCESS, response));
+  }
+
+  @Operation(summary = "내 정보 조회", description = "Access Token으로 인증된 유저의 정보를 반환합니다.")
+  @SecurityRequirement(name = "bearerAuth")  // Swagger에서 자물쇠 아이콘 활성화
+  @GetMapping("/me")
+  public ResponseEntity<BaseResponse<UserResponse>> getMe(Authentication authentication) {
+    // SecurityConfig에서 anyRequest().authenticated()로 보호하지만
+    // 혹시 필터가 누락될 경우를 대비한 방어 코드
+    if (authentication == null || authentication.getPrincipal() == null) {
+      throw new UserException(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    // JwtAuthFilter에서 principal에 userId(String)를 담아뒀으므로 파싱해서 사용
+    Long userId = Long.parseLong(authentication.getName());
+    UserResponse response = userService.getUserById(userId);
+    return ResponseEntity
+        .status(UserSuccessCode.USER_GET_ME_SUCCESS.getHttpStatus())
+        .body(BaseResponse.onSuccess(UserSuccessCode.USER_GET_ME_SUCCESS, response));
+  }
+}

--- a/src/main/java/org/sopt/domain/user/dto/request/CreateUserRequest.java
+++ b/src/main/java/org/sopt/domain/user/dto/request/CreateUserRequest.java
@@ -1,0 +1,24 @@
+package org.sopt.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원 가입 요청")
+public record CreateUserRequest(
+    @Schema(description = "닉네임", example = "솝트햄")
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    @Size(max = 20, message = "닉네임은 20자 이내로 입력해주세요.")
+    String nickname,
+
+    @Schema(description = "이메일", example = "sopt@example.com")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    String email,
+
+    @Schema(description = "비밀번호", example = "sopt1234!")
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    String password
+) {}

--- a/src/main/java/org/sopt/domain/user/dto/response/CreateUserResponse.java
+++ b/src/main/java/org/sopt/domain/user/dto/response/CreateUserResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.domain.user.entity.User;
+
+@Schema(description = "회원 가입 응답")
+public record CreateUserResponse(
+    @Schema(description = "생성된 유저 ID", example = "1")
+    Long id,
+    @Schema(description = "닉네임", example = "솝트햄")
+    String nickname,
+    @Schema(description = "이메일", example = "sopt@example.com")
+    String email
+) {
+  public static CreateUserResponse from(User user) {
+    return new CreateUserResponse(user.getId(), user.getNickname(), user.getEmail());
+  }
+}

--- a/src/main/java/org/sopt/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/org/sopt/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.sopt.domain.user.entity.User;
+
+@Schema(description = "유저 정보 응답")
+public record UserResponse(
+        @Schema(description = "유저 ID", example = "1")
+        Long id,
+        @Schema(description = "닉네임", example = "솝트햄")
+        String nickname,
+        @Schema(description = "이메일", example = "sopt@example.com")
+        String email
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(user.getId(), user.getNickname(), user.getEmail());
+    }
+}

--- a/src/main/java/org/sopt/domain/user/entity/AuthProvider.java
+++ b/src/main/java/org/sopt/domain/user/entity/AuthProvider.java
@@ -1,0 +1,6 @@
+package org.sopt.domain.user.entity;
+
+public enum AuthProvider {
+    LOCAL,   // 이메일·비밀번호 직접 회원가입
+    GOOGLE   // Google OAuth 2.0 소셜 로그인
+}

--- a/src/main/java/org/sopt/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package org.sopt.domain.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,18 +21,37 @@ public class User extends BaseTimeEntity {
   @Column(nullable = false, length = 20)
   private String nickname;
 
-  @Column(nullable = false)
+  // OAuth 유저는 비밀번호가 없으므로 nullable
+  // 로그인 시 password == null이면 BCrypt 비교 대신 dummyHash를 사용해 항상 실패 처리
+  @Column(nullable = true)
   private String password;
 
   @Column(nullable = false, unique = true)
   private String email;
-  
+
+  // 기존 row 마이그레이션을 위해 DB 기본값 'LOCAL'로 설정
+  // ddl-auto: update 시 새 컬럼이 추가되며 기존 row는 자동으로 LOCAL로 채워짐
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "VARCHAR(10) DEFAULT 'LOCAL'")
+  private AuthProvider provider = AuthProvider.LOCAL;
+
   protected User() {}
 
   public User(String nickname, String email, String password) {
     this.nickname = nickname;
     this.email = email;
     this.password = password;
+    this.provider = AuthProvider.LOCAL;
+  }
+
+  // OAuth 유저 생성 — 비밀번호 없음, provider 명시
+  public static User ofOAuth(String nickname, String email, AuthProvider provider) {
+    User user = new User();
+    user.nickname = nickname;
+    user.email = email;
+    user.password = null;
+    user.provider = provider;
+    return user;
   }
 
   public Long getId() {

--- a/src/main/java/org/sopt/domain/user/entity/User.java
+++ b/src/main/java/org/sopt/domain/user/entity/User.java
@@ -19,14 +19,18 @@ public class User extends BaseTimeEntity {
   @Column(nullable = false, length = 20)
   private String nickname;
 
+  @Column(nullable = false)
+  private String password;
+
   @Column(nullable = false, unique = true)
   private String email;
   
   protected User() {}
 
-  public User(String nickname, String email) {
+  public User(String nickname, String email, String password) {
     this.nickname = nickname;
     this.email = email;
+    this.password = password;
   }
 
   public Long getId() {
@@ -39,5 +43,9 @@ public class User extends BaseTimeEntity {
 
   public String getEmail() {
     return this.email;
+  }
+
+  public String getPassword() {
+    return this.password;
   }
 }

--- a/src/main/java/org/sopt/domain/user/exception/UserException.java
+++ b/src/main/java/org/sopt/domain/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package org.sopt.domain.user.exception;
+
+import org.sopt.global.exception.CustomException;
+import org.sopt.global.exception.code.BaseErrorCode;
+
+public class UserException extends CustomException {
+
+  public UserException(BaseErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/org/sopt/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/org/sopt/domain/user/exception/code/UserErrorCode.java
@@ -1,0 +1,35 @@
+package org.sopt.domain.user.exception.code;
+
+import org.sopt.global.exception.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode implements BaseErrorCode {
+
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4041", "해당 유저를 찾을 수 없습니다."),
+  USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "USER4091", "이미 사용 중인 이메일입니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  UserErrorCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/org/sopt/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/org/sopt/domain/user/exception/code/UserSuccessCode.java
@@ -1,0 +1,35 @@
+package org.sopt.domain.user.exception.code;
+
+import org.sopt.global.exception.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserSuccessCode implements BaseSuccessCode {
+
+  USER_JOIN_SUCCESS(HttpStatus.CREATED, "USER2011", "회원 가입에 성공했습니다."),
+  USER_GET_ME_SUCCESS(HttpStatus.OK, "USER2001", "내 정보 조회에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  UserSuccessCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/main/java/org/sopt/domain/user/service/UserService.java
+++ b/src/main/java/org/sopt/domain/user/service/UserService.java
@@ -1,0 +1,47 @@
+package org.sopt.domain.user.service;
+
+import org.sopt.domain.user.dto.request.CreateUserRequest;
+import org.sopt.domain.user.dto.response.CreateUserResponse;
+import org.sopt.domain.user.dto.response.UserResponse;
+import org.sopt.domain.user.entity.User;
+import org.sopt.domain.user.exception.UserException;
+import org.sopt.domain.user.exception.code.UserErrorCode;
+import org.sopt.domain.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  @Transactional
+  public CreateUserResponse join(CreateUserRequest request) {
+    if (userRepository.findByEmail(request.email()).isPresent()) {
+      throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATED);
+    }
+
+    // encode(): BCrypt 해시 + 랜덤 솔트를 생성하여 "$2a$10$..." 형태로 반환
+    // 원문 비밀번호는 저장하지 않으므로 DB 유출 시에도 원문 복원 불가
+    String encodedPassword = passwordEncoder.encode(request.password());
+
+    User savedUser = userRepository.save(
+        new User(request.nickname(), request.email(), encodedPassword)
+    );
+    return CreateUserResponse.from(savedUser);
+  }
+
+  @Transactional(readOnly = true)
+  public UserResponse getUserById(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    return UserResponse.from(user);
+  }
+}

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -1,0 +1,101 @@
+package org.sopt.global.config;
+
+import org.sopt.global.jwt.JwtAccessDeniedHandler;
+import org.sopt.global.jwt.JwtAuthFilter;
+import org.sopt.global.jwt.JwtAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity  // @PreAuthorize, @PostAuthorize 등 메서드 레벨 보안 활성화
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    public SecurityConfig(
+            JwtAuthFilter jwtAuthFilter,
+            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+            JwtAccessDeniedHandler jwtAccessDeniedHandler
+    ) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // REST API는 CSRF 공격 대상이 아님 (쿠키 기반 세션 없음) — JWT Bearer 토큰 방식 사용
+            .csrf(csrf -> csrf.disable())
+
+            // 서버에 세션을 저장하지 않음 — JWT가 상태를 대신 관리
+            // STATELESS로 설정하면 Spring Security가 세션을 절대 생성·사용하지 않음
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            .authorizeHttpRequests(auth -> auth
+                // ── 인증 불필요 (공개 엔드포인트) ──────────────────────────────
+                // 로그인·재발급은 토큰을 발급하는 진입점이므로 토큰 없이 접근 가능해야 함
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()
+
+                // 회원가입도 토큰 없이 접근 가능
+                .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
+
+                // 게시글·검색 조회는 비로그인 접근 허용 (에브리타임 스타일)
+                // HttpMethod.GET으로 좁혀서 POST /api/v1/posts(게시글 작성)는 인증 필요 상태 유지
+                .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+
+                // Swagger UI — 개발·테스트 편의를 위해 허용
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+
+                // ── 인증 필요 ────────────────────────────────────────────────────
+                // 위에서 permitAll()로 명시된 것 외 모든 요청(POST/PUT/DELETE 게시글, 좋아요 등)
+                .anyRequest().authenticated()
+            )
+
+            // Spring Security 기본 인증 필터 앞에 JWT 필터 삽입
+            // JwtAuthFilter → UsernamePasswordAuthenticationFilter 순으로 실행됨
+            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+
+            // 필터 단에서 발생하는 예외를 우리 BaseResponse 형식으로 통일
+            // 미등록 시 Spring Security 기본 동작(규격 없는 HTML/JSON)이 반환되어 API 응답 형식이 깨짐
+            .exceptionHandling(ex -> ex
+                    // 토큰 없음·만료 → 401
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                    // 인증은 됐지만 Spring Security 레벨에서 거부 → 403
+                    .accessDeniedHandler(jwtAccessDeniedHandler)
+            );
+
+        return http.build();
+    }
+
+    /**
+     * BCrypt 해시 함수 기반 PasswordEncoder 빈 등록.
+     *
+     * BCrypt를 선택한 이유:
+     *  1. 자동 솔트 내장: encode() 호출마다 랜덤 솔트가 생성되어 동일 비밀번호도 매번 다른 해시 생성
+     *     → 레인보우 테이블 공격 무력화
+     *  2. 단방향 해시: 해시에서 원문 복원 불가 → DB 유출 시에도 비밀번호 안전
+     *  3. 연산 비용 조절 가능: 기본 strength(cost factor) 10은 해시 1회에 ~100ms 소요
+     *     → 브루트포스 시도 속도를 실질적으로 제한
+     *
+     * matches(rawPassword, encodedPassword)가 솔트 추출·재해시·비교를 내부적으로 처리하므로
+     * 개발자가 솔트를 직접 관리할 필요 없음.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -49,6 +49,11 @@ public class SecurityConfig {
                 // 로그인·재발급은 토큰을 발급하는 진입점이므로 토큰 없이 접근 가능해야 함
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue").permitAll()
+                // Google 인가 코드를 받아 JWT를 발급하는 진입점 — 토큰 없이 접근 가능해야 함
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/google").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/auth/google/authorize").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/auth/google/callback").permitAll()
+                .requestMatchers("/oauth-test.html").permitAll()
 
                 // 회원가입도 토큰 없이 접근 가능
                 .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()

--- a/src/main/java/org/sopt/global/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/global/config/SecurityConfig.java
@@ -52,7 +52,6 @@ public class SecurityConfig {
                 // Google 인가 코드를 받아 JWT를 발급하는 진입점 — 토큰 없이 접근 가능해야 함
                 .requestMatchers(HttpMethod.POST, "/api/v1/auth/google").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/auth/google/authorize").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/v1/auth/google/callback").permitAll()
                 .requestMatchers("/oauth-test.html").permitAll()
 
                 // 회원가입도 토큰 없이 접근 가능

--- a/src/main/java/org/sopt/global/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/global/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package org.sopt.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
@@ -10,14 +12,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class SwaggerConfig implements WebMvcConfigurer {
 
-  // 1. API 문서 기본 정보 설정 (제목, 버전 등)
+  // 1. API 문서 기본 정보 + Bearer 토큰 인증 스키마 등록
+  // @SecurityRequirement(name = "bearerAuth")가 붙은 엔드포인트에 자물쇠 아이콘이 나타남
   @Bean
   public OpenAPI openAPI() {
     return new OpenAPI()
         .info(new Info()
             .title("SOPT ASSIGNMENT API")
             .description("SOPT assignment API 명세서입니다.")
-            .version("v1.0.0"));
+            .version("v1.0.0"))
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")));
   }
 
   // 2. 루트 경로(/) 접속 시 Swagger UI로 자동 리다이렉트

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -1,16 +1,14 @@
 package org.sopt.global.exception;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.sopt.domain.auth.exception.code.AuthErrorCode;
-import org.sopt.domain.like.exception.code.LikeErrorCode;
-import org.sopt.domain.post.exception.code.PostErrorCode;
-import org.sopt.domain.user.exception.code.UserErrorCode;
 import org.sopt.global.exception.code.BaseErrorCode;
-import org.sopt.global.exception.code.GlobalErrorCode;
 import org.sopt.global.response.BaseResponse;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -75,22 +73,30 @@ public class GlobalExceptionHandler {
         .body(BaseResponse.onFailure("COMMON4001", defaultMessage));
   }
 
-  private static final Map<String, BaseErrorCode> errorCodeMap = new HashMap<>();
+  private final Map<String, BaseErrorCode> errorCodeMap = new HashMap<>();
 
-  static {
-    // 애플리케이션 실행 시 딱 한 번만 모든 메시지를 맵에 담아둠
-    List<Class<? extends BaseErrorCode>> enums = List.of(
-        PostErrorCode.class, LikeErrorCode.class, GlobalErrorCode.class,
-        UserErrorCode.class, AuthErrorCode.class
-    );
-    for (Class<? extends BaseErrorCode> enumClass : enums) {
-      for (BaseErrorCode code : enumClass.getEnumConstants()) {
-        errorCodeMap.put(code.getMessage(), code);
-      }
+  // 애플리케이션 시작 시 org.sopt 하위의 BaseErrorCode 구현 enum을 자동 탐색해 맵에 등록
+  // 새 도메인 ErrorCode를 추가해도 이 파일을 수정할 필요 없음
+  @PostConstruct
+  public void initErrorCodeMap() {
+    ClassPathScanningCandidateComponentProvider scanner =
+        new ClassPathScanningCandidateComponentProvider(false);
+    scanner.addIncludeFilter(new AssignableTypeFilter(BaseErrorCode.class));
+
+    for (BeanDefinition bd : scanner.findCandidateComponents("org.sopt")) {
+      try {
+        Class<?> clazz = Class.forName(bd.getBeanClassName());
+        if (clazz.isEnum()) {
+          for (Object constant : clazz.getEnumConstants()) {
+            BaseErrorCode code = (BaseErrorCode) constant;
+            errorCodeMap.put(code.getMessage(), code);
+          }
+        }
+      } catch (ClassNotFoundException ignored) {}
     }
   }
 
   private BaseErrorCode findErrorCodeByMessage(String message) {
-    return errorCodeMap.get(message); // 이제 반복문 없이 O(1)으로 즉시 찾음!
+    return errorCodeMap.get(message);
   }
 }

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -4,8 +4,10 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.sopt.domain.auth.exception.code.AuthErrorCode;
 import org.sopt.domain.like.exception.code.LikeErrorCode;
 import org.sopt.domain.post.exception.code.PostErrorCode;
+import org.sopt.domain.user.exception.code.UserErrorCode;
 import org.sopt.global.exception.code.BaseErrorCode;
 import org.sopt.global.exception.code.GlobalErrorCode;
 import org.sopt.global.response.BaseResponse;
@@ -77,7 +79,10 @@ public class GlobalExceptionHandler {
 
   static {
     // 애플리케이션 실행 시 딱 한 번만 모든 메시지를 맵에 담아둠
-    List<Class<? extends BaseErrorCode>> enums = List.of(PostErrorCode.class, LikeErrorCode.class, GlobalErrorCode.class);
+    List<Class<? extends BaseErrorCode>> enums = List.of(
+        PostErrorCode.class, LikeErrorCode.class, GlobalErrorCode.class,
+        UserErrorCode.class, AuthErrorCode.class
+    );
     for (Class<? extends BaseErrorCode> enumClass : enums) {
       for (BaseErrorCode code : enumClass.getEnumConstants()) {
         errorCodeMap.put(code.getMessage(), code);

--- a/src/main/java/org/sopt/global/jwt/AccessTokenBlacklistService.java
+++ b/src/main/java/org/sopt/global/jwt/AccessTokenBlacklistService.java
@@ -1,0 +1,57 @@
+package org.sopt.global.jwt;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 로그아웃된 Access Token을 Redis 블랙리스트로 관리한다.
+ *
+ * ── 이전 구현: In-memory (ConcurrentHashMap) ─────────────────────────────
+ * 서버 재시작 시 초기화, 다중 인스턴스 환경에서 공유 불가, @Scheduled 정리 필요
+ *
+ * ── 현재 구현: Redis ─────────────────────────────────────────────────────
+ * SET blacklist:<token> "1" EX <남은 초>
+ * - TTL이 만료되면 Redis가 자동으로 키를 삭제 → @Scheduled 정리 불필요
+ * - 서버 재시작과 무관하게 블랙리스트 유지
+ * - 다중 인스턴스 환경에서도 공유됨 (로드 밸런서 뒤 여러 서버 가능)
+ */
+@Service
+public class AccessTokenBlacklistService {
+
+    // 키 충돌 방지를 위한 네임스페이스 접두사
+    // Redis는 모든 키가 단일 네임스페이스라 다른 용도의 키와 구분하기 위해 prefix 사용
+    private static final String PREFIX = "blacklist:";
+
+    // StringRedisTemplate: 키·값 모두 String인 단순 구조에 최적화된 Redis 클라이언트
+    // RedisTemplate<Object, Object>보다 직렬화 설정이 간단하고 오버헤드가 적음
+    private final StringRedisTemplate redisTemplate;
+
+    public AccessTokenBlacklistService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 로그아웃된 토큰을 블랙리스트에 등록한다.
+     *
+     * TTL = (토큰 만료 시각 - 현재 시각): 토큰이 만료되면 블랙리스트에도 불필요하므로
+     * 같은 시점에 Redis 키가 자동 삭제되도록 설정한다.
+     * TTL이 0 이하면 이미 만료된 토큰 — 저장하지 않아도 JWT 검증에서 막히므로 무시한다.
+     */
+    public void blacklist(String token, Instant expiresAt) {
+        long ttlSeconds = expiresAt.getEpochSecond() - Instant.now().getEpochSecond();
+        if (ttlSeconds > 0) {
+            redisTemplate.opsForValue().set(PREFIX + token, "1", Duration.ofSeconds(ttlSeconds));
+        }
+    }
+
+    /**
+     * 블랙리스트 여부를 확인한다.
+     * Redis의 EXISTS 명령으로 O(1) 조회 — 토큰이 만료되면 Redis가 키를 자동 삭제하므로
+     * 별도의 만료 시각 비교 없이 키 존재 여부만 확인하면 됨.
+     */
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + token));
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,47 @@
+package org.sopt.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.sopt.domain.auth.exception.code.AuthErrorCode;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증은 됐지만 Spring Security 레벨에서 접근이 거부될 때 호출된다.
+ * 예: @PreAuthorize, @Secured 등 메서드 보안 어노테이션 실패
+ *
+ * 게시글 소유권 검증(POST_FORBIDDEN)처럼 서비스 레이어에서 던지는 예외는
+ * GlobalExceptionHandler가 처리하므로 이 핸들러를 거치지 않는다.
+ * 이 핸들러는 Spring Security 자체가 막는 경우(필터·인터셉터 레벨)에만 호출된다.
+ */
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(AuthErrorCode.AUTH_FORBIDDEN.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        BaseResponse<Void> body = BaseResponse.onFailure(
+                AuthErrorCode.AUTH_FORBIDDEN.getCode(),
+                AuthErrorCode.AUTH_FORBIDDEN.getMessage()
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
@@ -7,6 +7,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,10 +20,14 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
 
-    private final JwtService jwtService;
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthFilter.class);
 
-    public JwtAuthFilter(JwtService jwtService) {
+    private final JwtService jwtService;
+    private final AccessTokenBlacklistService blacklistService;
+
+    public JwtAuthFilter(JwtService jwtService, AccessTokenBlacklistService blacklistService) {
         this.jwtService = jwtService;
+        this.blacklistService = blacklistService;
     }
 
     @Override
@@ -35,6 +42,20 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             String token = header.substring("Bearer ".length()).trim();
             try {
                 Long userId = jwtService.verifyAndGetUserId(token);
+
+                // 서명·만료가 유효해도 로그아웃된 토큰이면 인증 거부
+                // 블랙리스트 체크는 JWT 검증 이후에 수행 — 위변조·만료 토큰은 어차피 위에서 걸러짐
+                try {
+                    if (blacklistService.isBlacklisted(token)) {
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
+                } catch (RedisConnectionFailureException e) {
+                    // Redis 장애 시 fail-open: 블랙리스트 확인을 건너뛰고 인증을 허용한다.
+                    // fail-closed(인증 거부)로 바꾸면 보안은 강해지지만 Redis 장애가 전체 서비스 중단으로 이어짐.
+                    // 로그아웃 토큰이 일시적으로 유효해지는 위험보다 가용성을 우선하는 판단.
+                    log.warn("Redis 연결 실패로 블랙리스트 확인을 건너뜁니다: {}", e.getMessage());
+                }
 
                 // principal에 userId(String)를 담아 SecurityContext에 저장
                 // 이후 컨트롤러에서 authentication.getName()으로 userId를 꺼낼 수 있음

--- a/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,55 @@
+package org.sopt.global.jwt;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    public JwtAuthFilter(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring("Bearer ".length()).trim();
+            try {
+                Long userId = jwtService.verifyAndGetUserId(token);
+
+                // principal에 userId(String)를 담아 SecurityContext에 저장
+                // 이후 컨트롤러에서 authentication.getName()으로 userId를 꺼낼 수 있음
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                        String.valueOf(userId), null, Collections.emptyList());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+
+            } catch (IllegalArgumentException | JWTVerificationException e) {
+                // 유효하지 않은 토큰은 인증 없이 다음 필터로 넘김
+                // 예외를 여기서 던지지 않는 이유: /api/v1/auth/login 같이 인증이 필요 없는
+                // 엔드포인트도 이 필터를 통과하기 때문 — 인증 필요 여부는 SecurityConfig에서 판단
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package org.sopt.global.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.sopt.domain.auth.exception.code.AuthErrorCode;
+import org.sopt.global.response.BaseResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증되지 않은 요청이 보호된 엔드포인트에 접근할 때 호출된다.
+ *
+ * Spring Security는 필터 단에서 예외를 처리하므로 GlobalExceptionHandler에 도달하지 않는다.
+ * 이 클래스를 등록하지 않으면 Spring Security 기본 동작(HTML 에러 페이지 또는 규격 없는 403)이 반환되어
+ * API 응답 형식이 깨진다 — 우리 BaseResponse 포맷으로 통일하기 위해 직접 JSON을 작성한다.
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(AuthErrorCode.AUTH_UNAUTHORIZED.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        BaseResponse<Void> body = BaseResponse.onFailure(
+                AuthErrorCode.AUTH_UNAUTHORIZED.getCode(),
+                AuthErrorCode.AUTH_UNAUTHORIZED.getMessage()
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtService.java
+++ b/src/main/java/org/sopt/global/jwt/JwtService.java
@@ -1,0 +1,71 @@
+package org.sopt.global.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.time.Instant;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+    private final Algorithm algorithm;
+    private final long accessTokenExpiresInSeconds;
+    private final long refreshTokenExpiresInSeconds;
+
+    public JwtService(
+            @Value("${security.jwt.secret}") String secret,
+            @Value("${security.jwt.access-token-expires-in-seconds:1800}") long accessTokenExpiresInSeconds,
+            @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}") long refreshTokenExpiresInSeconds
+    ) {
+        // HMAC256: 서버만 아는 secret key로 서명 — 서버가 직접 검증 가능 (비대칭 키 불필요)
+        this.algorithm = Algorithm.HMAC256(secret);
+        this.accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;
+        this.refreshTokenExpiresInSeconds = refreshTokenExpiresInSeconds;
+    }
+
+    /**
+     * Access Token 발급
+     * subject에 userId, claim에 email을 담아 서버 식별 및 추가 정보 조회 없이 바로 활용할 수 있게 함
+     */
+    public String generateAccessToken(Long userId, String email) {
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withClaim("email", email)
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(accessTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    /**
+     * Refresh Token 발급
+     * Access Token 재발급 용도로만 쓰이므로 subject(userId)만 담음
+     */
+    public String generateRefreshToken(Long userId) {
+        Instant now = Instant.now();
+        return JWT.create()
+                .withSubject(String.valueOf(userId))
+                .withIssuedAt(Date.from(now))
+                .withExpiresAt(Date.from(now.plusSeconds(refreshTokenExpiresInSeconds)))
+                .sign(algorithm);
+    }
+
+    /**
+     * 토큰 검증 후 userId 추출
+     * 만료/위변조 시 JWT 라이브러리가 JWTVerificationException을 던짐
+     */
+    public Long verifyAndGetUserId(String token) {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("토큰이 없습니다.");
+        }
+        DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+        try {
+            return Long.parseLong(jwt.getSubject());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("JWT의 유저 정보가 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/org/sopt/global/jwt/JwtService.java
+++ b/src/main/java/org/sopt/global/jwt/JwtService.java
@@ -68,4 +68,12 @@ public class JwtService {
             throw new IllegalArgumentException("JWT의 유저 정보가 올바르지 않습니다.");
         }
     }
+
+    /**
+     * 토큰의 만료 시각을 반환한다.
+     * 로그아웃 시 블랙리스트 TTL 설정에 사용 — 만료 이후에는 블랙리스트에 없어도 JWT 자체가 무효
+     */
+    public Instant getExpiry(String token) {
+        return JWT.require(algorithm).build().verify(token).getExpiresAtAsInstant();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,4 +56,6 @@ oauth:
     # Google userinfo endpoint — access token으로 유저 정보(이메일, 이름) 조회
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
     # Google이 로그인 완료 후 돌아오는 우리 서버 주소 (Google Cloud Console에 등록된 값과 일치해야 함)
-    callback-uri: ${GOOGLE_CALLBACK_URI:http://localhost:8080/api/v1/auth/google/callback}
+    # 개발 환경: oauth-test.html이 프론트 역할을 하므로 이 페이지로 리다이렉트
+    # 운영 환경: 실제 프론트엔드 URL로 교체 (환경변수로 주입)
+    callback-uri: ${GOOGLE_CALLBACK_URI:http://localhost:8080/oauth-test.html}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
     name: assignment
 
   data:
+    redis:
+      host: ${REDIS_HOST:localhost}  # 환경변수 없으면 localhost 기본값 사용
+      port: ${REDIS_PORT:6379}
     web:
       pageable:
         default-page-size: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,9 @@ spring:
       groups-order: DESC                # 최근 생성된 API가 위로 오도록 정렬
     default-consume-media-type: application/json
     default-produce-media-type: application/json
+
+security:
+  jwt:
+    secret: ${JWT_SECRET_KEY}
+    access-token-expires-in-seconds: 1800     # 30분
+    refresh-token-expires-in-seconds: 1209600 # 2주

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,16 @@ security:
     secret: ${JWT_SECRET_KEY}
     access-token-expires-in-seconds: 1800     # 30분
     refresh-token-expires-in-seconds: 1209600 # 2주
+
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    # 사용자를 Google 로그인 화면으로 보내는 URL
+    authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+    # Google token endpoint — authorization code를 access token으로 교환
+    token-uri: https://oauth2.googleapis.com/token
+    # Google userinfo endpoint — access token으로 유저 정보(이메일, 이름) 조회
+    user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+    # Google이 로그인 완료 후 돌아오는 우리 서버 주소 (Google Cloud Console에 등록된 값과 일치해야 함)
+    callback-uri: ${GOOGLE_CALLBACK_URI:http://localhost:8080/api/v1/auth/google/callback}

--- a/src/main/resources/static/oauth-test.html
+++ b/src/main/resources/static/oauth-test.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Google 로그인 테스트</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: 'Apple SD Gothic Neo', sans-serif;
+            background: #f5f5f5;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+        }
+        .card {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 2px 16px rgba(0,0,0,0.1);
+            padding: 48px 40px;
+            width: 400px;
+            text-align: center;
+        }
+        h2 { font-size: 20px; color: #333; margin-bottom: 32px; }
+        .google-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            background: white;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            padding: 12px 24px;
+            font-size: 15px;
+            color: #333;
+            text-decoration: none;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+        .google-btn:hover { background: #f8f8f8; }
+        .google-btn img { width: 20px; height: 20px; }
+        .result {
+            margin-top: 32px;
+            text-align: left;
+            display: none;
+        }
+        .result h3 { font-size: 15px; color: #4caf50; margin-bottom: 12px; }
+        .result pre {
+            background: #f5f5f5;
+            border-radius: 6px;
+            padding: 16px;
+            font-size: 13px;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+        .error h3 { color: #f44336; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h2>Google 소셜 로그인 테스트</h2>
+        <a href="/api/v1/auth/google/authorize" class="google-btn">
+            <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google">
+            Google로 로그인
+        </a>
+        <div class="result" id="result">
+            <h3 id="result-title"></h3>
+            <pre id="result-body"></pre>
+        </div>
+    </div>
+
+    <script>
+        // 콜백으로 돌아왔을 때 URL에 code가 있으면 서버에 자동 요청
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        const error = params.get('error');
+
+        if (error) {
+            showResult(false, { error });
+        } else if (code) {
+            fetch('/api/v1/auth/google/callback?code=' + encodeURIComponent(code))
+                .then(res => res.json())
+                .then(data => showResult(true, data))
+                .catch(err => showResult(false, { error: err.message }));
+        }
+
+        function showResult(success, data) {
+            const resultEl = document.getElementById('result');
+            const titleEl = document.getElementById('result-title');
+            const bodyEl = document.getElementById('result-body');
+
+            resultEl.style.display = 'block';
+            resultEl.className = 'result' + (success ? '' : ' error');
+            titleEl.textContent = success ? '로그인 성공!' : '로그인 실패';
+            bodyEl.textContent = JSON.stringify(data, null, 2);
+        }
+    </script>
+</body>
+</html>

--- a/src/main/resources/static/oauth-test.html
+++ b/src/main/resources/static/oauth-test.html
@@ -70,7 +70,8 @@
     </div>
 
     <script>
-        // 콜백으로 돌아왔을 때 URL에 code가 있으면 서버에 자동 요청
+        // Google이 이 페이지로 리다이렉트하면 URL에 code가 포함됨
+        // 프론트엔드처럼 code + redirectUri를 POST /api/v1/auth/google로 전송
         const params = new URLSearchParams(window.location.search);
         const code = params.get('code');
         const error = params.get('error');
@@ -78,7 +79,14 @@
         if (error) {
             showResult(false, { error });
         } else if (code) {
-            fetch('/api/v1/auth/google/callback?code=' + encodeURIComponent(code))
+            fetch('/api/v1/auth/google', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    code: code,
+                    redirectUri: window.location.origin + window.location.pathname
+                })
+            })
                 .then(res => res.json())
                 .then(data => showResult(true, data))
                 .catch(err => showResult(false, { error: err.message }));


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 오늘 실습한 JWT + Spring Security 인증을 에브리타임 클론 프로젝트 전체에 적용해주세요. 로그인/토큰 재발급 API는 인증 없이 접근 가능하고, 게시글 작성/수정/삭제, 좋아요 추가/취소는 인증이 필요하도록 설정해주세요.
- [x] 비밀번호를 평문으로 저장하는 건 위험해요. BCryptPasswordEncoder를 사용해서 비밀번호를 암호화해서 저장하고, 로그인 시 matches()로 검증하도록 수정해주세요.

<br>

### 선택과제
- [x] 로그아웃 API를 구현해주세요. 로그아웃 시 DB에서 해당 유저의 Refresh Token을 삭제하고, 현재 Access Token을 블랙리스트에 추가해서 만료 전에도 사용할 수 없도록 해주세요. Access Token이 만료됐을 때 클라이언트가 어떻게 401을 감지해서 로그인 페이지로 이동시킬지 흐름도 함께 작성해주세요.
- [x] Kakao 또는 Google OAuth 2.0 소셜 로그인을 구현해주세요. 외부 인증 서버로부터 유저 정보를 받아온 후, 우리 서버에서 JWT(Access Token + Refresh Token)를 발급하는 흐름까지 완성해주세요. 신규 유저라면 자동으로 회원가입 처리하고, 기존 유저라면 로그인 처리해주세요.

<br>

### **구현한 내용에 대해서 설명해주세요**

**<필수 과제>**

- 회원 도메인
  - 회원가입 API 구현 (POST /api/v1/users)
  - 비밀번호를 BCryptPasswordEncoder로 암호화하여 저장

- JWT 인증 시스템
  - JwtService: HMAC256 알고리즘 기반 Access Token(30분), Refresh Token(2주) 발급·검증
  - JwtAuthFilter: 매 요청마다 Authorization: Bearer <token> 헤더를 파싱해 userId를 SecurityContext에 저장
  - SecurityConfig: 공개 엔드포인트(로그인, 회원가입, 게시글 조회)는 permitAll(), 나머지는 authenticated()

- Auth 도메인
  - 로그인 API (POST /api/v1/auth/login): 이메일·비밀번호 검증 후 토큰 쌍 발급
  - 토큰 재발급 API (POST /api/v1/auth/reissue): Refresh Token Rotation 방식으로 Access Token + Refresh Token 동시 교체. DB에 유저당 토큰 1개만 유지

- 인증·인가 적용
  - 게시글 작성·수정·삭제, 좋아요 추가·취소는 유효한 Access Token 필요
  - 게시글 수정·삭제 시 작성자 본인 여부 검증 → 타인 글 접근 시 403 반환
  - 요청 바디·파라미터에서 userId 제거 → JWT에서 서버가 직접 추출하도록 변경

- 에러 응답 통일
  - JwtAuthenticationEntryPoint: 미인증 요청 → AUTH4010 (401)
  - JwtAccessDeniedHandler: Spring Security 레벨 거부 → AUTH4030 (403)
  - 기존에 Spring Security 기본 응답(규격 없는 403)으로 나오던 케이스를 BaseResponse 형식으로 통일

- 로그인 요청 방식 변경 (@RequestParam → @RequestBody)
  - 기존에 이메일·비밀번호를 @RequestParam으로 받고 있었는데, 이 경우 /api/v1/auth/login?email=...&password=평문 형태로 전송돼 서버 액세스 로그, 브라우저 히스토리, 프록시 로그에 비밀번호가 평문으로 남을 수 있습니다. @RequestBody로 변경해 HTTPS 페이로드 안에 포함되도록 수정했습니다.

---

**<선택 과제>**

**로그아웃 API (POST /api/v1/auth/logout)**

- 로그아웃 시 두 가지 작업을 수행합니다.

  1. DB에서 해당 유저의 Refresh Token을 삭제해 재발급 경로를 차단합니다. 이미 토큰이 없는 경우에도 예외를 던지지 않고 정상 처리해 멱등성을 보장합니다.
  2. 현재 Access Token을 Redis 블랙리스트에 등록합니다. JWT는 stateless라 서버가 단독으로 무효화할 수 없기 때문에, 만료 전 토큰을 차단하려면 서버 측에서 사용 금지 목록을 별도로 관리해야 합니다. JwtAuthFilter가 매 요청마다 블랙리스트를 확인해 등록된 토큰을 차단합니다.

- Redis 기반 Access Token 블랙리스트

  - 초기 구현은 ConcurrentHashMap + @Scheduled 정리였으나 두 가지 한계가 있었습니다.
  - 서버 재시작 시 블랙리스트 초기화 → 로그아웃한 유저의 토큰이 만료 전에 다시 유효해질 수 있음
  - 다중 인스턴스 환경에서 인스턴스 간 공유 불가

    Redis의 TTL 기능을 활용해 토큰 만료 시각과 동일한 TTL을 설정했습니다. 토큰이 JWT 자체적으로 만료되는 시점에 Redis 키도 자동 삭제되어 별도 스케줄러가 필요 없습니다.

- 클라이언트 401 감지 → 로그인 페이지 이동 흐름

  1. 클라이언트가 API 요청 시 Access Token이 만료되었거나 블랙리스트에 등록된 경우 서버가 401을 반환합니다.
  2. 클라이언트는 저장된 Refresh Token으로 /api/v1/auth/reissue를 호출합니다.
  3. 재발급 성공(200)이면 새 토큰을 저장하고 원래 요청을 재시도합니다.
  4. 재발급도 실패(401)이면 Refresh Token이 만료되었거나 로그아웃으로 DB에서 삭제된 것이므로, 저장된 토큰을 모두 제거하고 로그인 페이지로 이동시킵니다.

**Google OAuth 2.0 Authorization Code Flow (프론트엔드 주도)**

- 사용자 → GET /api/v1/auth/google/authorize (서버가 Google 인가 URL 조립)
         → Google 로그인 화면
         → oauth-test.html?code=... (Google 리다이렉트)
         → POST /api/v1/auth/google { code, redirectUri } (JS가 서버에 전송)
         → JWT 발급

- 신규 API
  - POST │ /api/v1/auth/google  │ Google code → JWT 발급 (메인 엔드포인트)
  - GET │ /api/v1/auth/google/authorize │ Google 인가 화면으로 리다이렉트 (개발용)

- 주요 구현 사항
  - GoogleOAuthClient: RestClient로 Google token/userinfo API 호출
  - 신규 유저는 자동 회원가입 (이메일 기반 계정 병합)
  - AuthProvider enum 추가 (LOCAL / GOOGLE)
  - User.password nullable로 변경 — OAuth 유저는 비밀번호 없음
  - oauth-test.html: 프론트엔드 없는 환경에서 실제 OAuth 플로우 테스트 가능한 페이지


**전체 흐름**

    1. 사용자가 oauth-test.html에서 버튼을 클릭하면 GET /api/v1/auth/google/authorize로 이동합니다.
    2. 서버가 client_id 등 민감한 값을 조립해 Google 인가 화면 URL로 리다이렉트합니다.
    3. 사용자가 Google 계정을 선택하면 Google이 oauth-test.html?code=...으로 리다이렉트합니다.
    4. oauth-test.html의 JS가 URL에서 code를 읽어 POST /api/v1/auth/google { code, redirectUri }로 서버에 전달합니다.
    5. 서버가 code로 Google token endpoint에서 access token을 교환합니다.
    6. 서버가 access token으로 Google userinfo API를 호출해 이메일·이름을 받아옵니다.
    7. 이메일로 기존 유저를 조회합니다. 없으면 자동 회원가입, 있으면 로그인 처리합니다.
    8. 기존 로그인과 동일하게 Access Token + Refresh Token을 발급합니다.
   
<img width="702" height="494" alt="image" src="https://github.com/user-attachments/assets/bb6e0cb8-671f-4fcb-b69a-ec0b17af1dac" />
<img width="694" height="410" alt="image" src="https://github.com/user-attachments/assets/0ae935cf-c646-4097-8c7a-008fe41554c7" />
<img width="1176" height="941" alt="image" src="https://github.com/user-attachments/assets/3da89922-54d0-4cfc-baae-917f4ea5324d" />


<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

**<필수 과제>**

- Refresh Token을 DB에 저장해야 하는 이유

  - JWT는 stateless라 서버가 단독으로 무효화할 수 없습니다. 로그아웃하거나 토큰을 재발급했을 때 기존 토큰을 못 쓰게 하려면 DB가 필요합니다. Rotation 방식을 선택한 이유는, 탈취된 Refresh Token이 공격자에 의해 사용되면 DB 토큰이 교체되어 이후 피해자의 재발급 시도가 실패하기 때문입니다. 이를 통해 침해 사실을 감지할 수 있습니다.

- 타이밍 공격을 처음에 놓쳤던 것

  - 로그인 실패 시 "이메일 또는 비밀번호" 통합 메시지를 쓴다고 생각했는데, 실제로는 이메일이 없으면 즉시 반환(~1ms), 비밀번호가 틀리면 BCrypt 연산 후 반환(~100ms)이라 응답 시간만으로 이메일 존재 여부를 알 수 있었습니다. 이메일이 없는 경우에도 더미 해시로 BCrypt를 실행해 응답 시간을 동일하게 만드는 방식으로 해결했습니다.

- 에러 응답 형식이 두 가지로 나오는 문제

  - Spring Security는 필터 단에서 예외를 처리하기 때문에 GlobalExceptionHandler까지 도달하지 않습니다. 인증 없이 접근하면 Spring Security 기본 응답이 나와서 클라이언트 입장에서 에러 처리 로직을 두 벌 만들어야 하는 문제가 있었습니다. AuthenticationEntryPoint와 AccessDeniedHandler를 직접 구현해 BaseResponse 형식으로 통일했습니다.

- 게시글 조회는 인증이 필요할까?

  - anyRequest().authenticated()로 설정하면 GET 요청도 막힙니다. 에브리타임처럼 로그인 없이도 게시글을 읽을 수 있어야 한다고  판단해, HttpMethod.GET으로 메서드를 좁혀서 조회만 permitAll()로 허용했습니다.

- findById vs getReferenceById

  - 좋아요 추가 시 JWT를 통과한 userId는 서버가 이미 검증한 값이므로 SELECT 없이 ID만 가진 JPA 프록시를 반환하는 getReferenceById()로 교체했습니다. 단, 이 경우 유저가 존재하지 않으면 EntityNotFoundException이 flush 시점에 발생하므로, JWT 검증이 선행됨을 전제로 합니다.

---
**<선택 과제>**

**로그아웃 API (POST /api/v1/auth/logout)**

- Redis 장애 시 fail-open vs fail-closed

  - JwtAuthFilter에서 isBlacklisted() 호출 시 Redis가 다운되면 RedisConnectionFailureException이 발생합니다. 처음에는 이 예외를 catch하지 않아, Redis 장애 시 유효한 토큰도 SecurityContext가 설정되지 않아 401이 반환되는 버그가 있었습니다.

  두 가지 전략을 고민했습니다.
    - fail-closed: 블랙리스트 확인 불가 시 인증 거부 → 보안은 강하지만 Redis 장애가 전체 서비스 중단으로 이어짐
    - fail-open: 블랙리스트 확인을 건너뛰고 인증 허용 → 로그아웃 토큰이 일시적으로 유효해지는 위험은 있지만 서비스 가용성 유지

  로그아웃된 토큰이 짧은 시간 살아나는 위험보다 Redis 장애로 인한 전체 서비스 중단이 더 큰 피해라고 판단해 fail-open을 채택하고, WARN 로그를 남겨 운영자가 장애를 인지할 수 있도록 했습니다.

- 로그아웃 토큰 저장 효율

  - 현재 Redis 키로 JWT 원문 전체(수백 바이트)를 사용합니다. JWT 발급 시 jti(JWT ID) 클레임을 추가하거나 토큰의 SHA-256 해시(32바이트)를 키로 사용하면 메모리를 절약할 수 있습니다. 현재 규모에서는 큰 문제가 아니지만 트래픽이 많아지면 개선이 필요한 지점입니다.

- Refresh Token Rotation과 단일 디바이스 로그아웃

  - deleteByUserId()로 해당 유저의 Refresh Token을 삭제하면 모든 기기에서 동시에 로그아웃됩니다. 기기별 Refresh Token을 독립적으로 관리하면 특정 기기만 로그아웃할 수 있지만, 그러면 Refresh Token 테이블 설계가 달라져야 합니다. 현재는 단순성을 위해 유저당 토큰 1개 정책을 유지했습니다.


**Google OAuth 2.0 Authorization Code Flow (프론트엔드 주도)**

- 프론트엔드 주도 방식을 선택한 이유
    - OAuth 구현 방식은 크게 두 가지입니다. 서버 주도는 서버가 Google callback을 직접 받아 리다이렉트까지 담당하고, 프론트엔드 주도는 프론트가 code를 받아 서버에 POST합니다. 서버 주도 방식은 서버가 리다이렉트를 처리해야 해서 REST API 설계와 맞지 않고, 프론트엔드가 생기면 흐름 전체를 다시 짜야 합니다. 프론트엔드 주도 방식을 선택하면 서버는 순수하게 토큰 발급만 담당하고, 실제 서비스에서 프론트가 붙어도 POST /api/v1/auth/google 하나만 호출하면 돼서 변경이 없습니다.

- 테스트 환경에서 프론트가 없는 문제는 oauth-test.html이 프론트 역할을 직접 수행하도록 해서 해결했습니다. 
  - Google이 이 페이지로 리다이렉트하면 URL에서 code를 읽어 POST /api/v1/auth/google을 JS로 직접 호출합니다. 서버 측 /callback 우회 엔드포인트 없이 실제 프론트와 동일한 흐름으로 테스트할 수 있습니다.
  
- OAuth 유저가 이메일/비밀번호 로그인을 시도할 때 타이밍 공격

    - Google로 가입한 유저는 password가 null입니다. 이 유저가 이메일/비밀번호 로그인을 시도하면 BCrypt를 건너뛰고 즉시 실패를 반환하게 됩니다. 이미 이메일 미존재 케이스에 대해 dummyHash로 BCrypt를 실행해 응답 시간을 동일하게 만들고 있었는데, OAuth 유저의 null password 케이스도 같은 문제였습니다. dummyHash 적용 조건을 user == null에서 user == null || user.getPassword() == null로 확장해 항상 BCrypt가 실행되도록 통일했습니다.

- OAuth 유저는 비밀번호가 없으므로 password 컬럼을 nullable로 변경해야 했습니다. 엔티티에 @Column(nullable = true)를 추가하고, ddl-auto: update는 새 컬럼·테이블 추가는 하지만 기존 컬럼의 제약 조건 변경은 하지 않으므로, ALTER TABLE users MODIFY COLUMN password VARCHAR(255) NULL로 직접 수정했습니다.



<br>

---
### **키워드 과제 정리내용**

## OAuth 2.0이란?

  OAuth 2.0은 **사용자가 자신의 비밀번호를 제3자 서비스에 직접 제공하지 않고도, 자신의 리소스에 대한 접근 권한을 위임할 수 있는 인증 위임 프로토콜**입니다.

  예를 들어 "Google로 로그인" 버튼을 클릭하면, 사용자는 Google에 로그인하고 우리 서버가 이메일·이름 정보를 가져올 수 있도록 허가만 합니다. 우리 서버는 Google 비밀번호를 전혀 알 수 없습니다.

  <br>

  ## 핵심 등장인물

  | 역할 | 설명 | 이번 구현에서 |
  |------|------|--------------|
  | Resource Owner | 리소스의 실제 주인 (사용자) | 서비스 사용자 |
  | Client | 리소스 접근을 요청하는 애플리케이션 | 우리 서버 |
  | Authorization Server | 인가 코드·토큰을 발급하는 서버 | Google 인증 서버 |
  | Resource Server | 보호된 리소스를 제공하는 서버 | Google userinfo API |

  <br>

  ## Authorization Code Flow

  이번 구현에서는 OAuth 2.0의 여러 방식 중 **Authorization Code Flow**를 사용했습니다. 보안성이 가장 높아 서버가 있는 웹 애플리케이션에서 표준으로 쓰입니다.
```
[사용자]         [우리 서버]            [Google]
   |                  |                     |
   | -- 로그인 클릭 --> |                     |
   |                  | -- 인가 URL 조립 --> |
   | <-- Google 인가 화면 리다이렉트 ---------|
   |                                        |
   | -- Google 계정 선택 -----------------> |
   | <-- authorization code 발급 ----------|
   |                                        |
   | -- code 전달 --> |                     |
   |                  | -- code로 access token 교환 --> |
   |                  | <-- access token --------------|
   |                  | -- access token으로 유저 정보 조회 -> |
   |                  | <-- 이메일, 이름 -----------------|
   |                  |                     |
   |                  | (회원가입 or 로그인 처리)
   | <-- JWT 발급 ----|
```

  <br>

  ## 왜 code를 바로 쓰지 않고 access token으로 교환할까?

  Google이 code를 사용자 브라우저(프론트)로 전달하기 때문에, code는 URL에 잠깐 노출됩니다. 만약 code 자체로 유저 정보를 바로 조회할 수 있다면 탈취 위험이 있습니다.

  code는 1회용이고 수명이 매우 짧습니다. 이 code를 **서버 간 통신**(우리 서버 → Google)으로 access token과 교환하면, client_secret이 서버에서만 사용되어 외부에 노출되지 않습니다. 이것이 Authorization Code Flow의 핵심 보안 장치입니다.

  <br>

  ## 프론트엔드 주도 vs 서버 주도

  | | 프론트엔드 주도 | 서버 주도 |
  |-|----------------|----------|
  | code 수신 | 프론트가 받아 서버에 POST | 서버가 직접 받음 |
  | 서버 역할 | 토큰 발급만 담당 | 리다이렉트까지 담당 |
  | REST 설계 | 적합 | 부적합 |
  | 이번 구현 | ✅ 채택 | — |

  프론트엔드 주도 방식을 채택하면 서버는 `POST /api/v1/auth/google { code, redirectUri }`만 받아 JWT를 발급하면 되고, 프론트엔드가 바뀌어도 서버 코드를 수정할 필요가 없습니다.

<br>

---

## 🚨 참고 사항
