### PR TITLE
Feat/#16/assignment 7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/config"]
+	path = src/main/resources/config
+	url = https://github.com/hamtorygoals/assignment-config

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   application:
     name: assignment
 
+  config:
+    import: classpath:config/application-secret.yml
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}  # 환경변수 없으면 localhost 기본값 사용


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 1차~6차 세미나에서 배운 내용 중 아직 글로 정리해보지 않은 주제를 골라서 아티클을 작성해주세요. 주제는 자유롭게 선택하되, 단순 요약이 아니라 내가 이해한 것을 내 언어로 설명하는 방식으로 써주세요.

<br>

### 선택과제
- [x] 아티클 주제와 관련된 기능을 에브리타임 클론 프로젝트에 직접 구현해주세요. 구현한 내용과 과정에서 배운 점을 PR 설명에 함께 작성해주세요.

<br>

### **구현한 내용에 대해서 설명해주세요**

민감한 설정값(DB 계정, JWT 시크릿, OAuth 키 등)을 메인 레포에서 분리하기 위해 Git 서브모듈 기반 설정 관리를 도입했습니다.

- 구조
  - hamtorygoals/assignment-config (private 레포)를 생성하고, 메인 프로젝트의 src/main/resources/config/ 경로에 서브모듈로 추가했습니다.
  - application-secret.yml에 민감한 설정값을 관리하고, application.yml에서 spring.config.import로 명시적으로 불러옵니다.

- 배포 흐름
  git clone --recurse-submodules <메인 레포>
  # 또는 이미 클론된 경우
  git submodule update --init --recursive
  **서브모듈만 업데이트하면 서버 접속 없이 설정값 변경이 반영되므로, 배포 환경에서 .env 파일이나 환경변수를 직접 관리할 필요가 없어집니다.**

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**

- 서브모듈 경로를 src/main/resources/config/로 잡은 이유

  - 처음에는 src/main/resources/ 바로 아래에 서브모듈을 추가하려 했지만, 해당 경로에 이미 파일이 존재하면 git submodule add가 실패했습니다. 이를 계기로 서브디렉토리인 config/에 두는 방식을 선택했는데, 오히려 더 나은 구조라고 판단했습니다. src/main/resources/ 바로 아래에 두면 Spring Boot가 application-*.yml 패턴으로 자동 로드할 수 있지만, config/ 하위에 두면 spring.config.import로 명시적으로 선언할 때만 로드됩니다. 의도가 코드에 드러나는 방식이라 더 명확하다고 판단했습니다.

- 빈 값이 환경변수를 override하는 문제

  - application-secret.yml에 값을 비워둔 채로(username:) 앱을 실행했더니 기존 환경변수(${DB_USERNAME})가
  무시되고 빈 값으로 덮어써지는 문제가 발생했습니다. spring.config.import로 불러온 파일의 우선순위가 더 높기
  때문입니다. 실제 값을 채우기 전까지는 해당 키를 주석 처리해 환경변수가 그대로 동작하도록 했습니다.

<br>

---

## 🚨 참고 사항
